### PR TITLE
Add basic CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.5)
+project(minix1 C)
+
+# Options for wini driver selection
+option(DRIVER_AT "Use AT wini driver" OFF)
+option(DRIVER_PC "Use PC/XT wini driver" OFF)
+
+if(DRIVER_AT AND DRIVER_PC)
+  message(FATAL_ERROR "Select only one of DRIVER_AT or DRIVER_PC")
+endif()
+
+# default to PC/XT driver
+if(DRIVER_AT)
+  set(WINI_DRIVER at)
+else()
+  set(WINI_DRIVER pc)
+endif()
+
+add_subdirectory(lib)
+add_subdirectory(kernel)
+add_subdirectory(mm)
+add_subdirectory(fs)
+add_subdirectory(commands)
+add_subdirectory(tools)
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Running `make` inside a component (for example `kernel` or `lib`) produces the
 corresponding binaries or libraries.  The `test` directory also provides
 makefiles for compiling small test programs.
 
+Alternatively the sources can be built with CMake.  From the repository root
+run:
+
+```sh
+cmake -B build
+cmake --build build
+```
+
+The kernel wini driver can be selected by passing `-DDRIVER_AT=ON` for the AT
+driver or `-DDRIVER_PC=ON` for the original PC/XT driver.  If neither option is
+specified the PC/XT driver is used.
+
 ## Documentation Note
 
 The repository originally included short `read_me` files under `doc` and `lib`.

--- a/commands/CMakeLists.txt
+++ b/commands/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB CMD_SRC *.c)
+foreach(src ${CMD_SRC})
+  get_filename_component(prog ${src} NAME_WE)
+  set(target cmd_${prog})
+  add_executable(${target} ${src})
+  target_link_libraries(${target} PRIVATE minixlib)
+endforeach()
+

--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB FS_SRC *.c)
+add_executable(fs ${FS_SRC})
+target_link_libraries(fs PRIVATE minixlib)
+

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Choose the correct wini driver source
+if(WINI_DRIVER STREQUAL "at")
+  set(WINI_SRC at_wini.c)
+else()
+  set(WINI_SRC xt_wini.c)
+endif()
+
+set(KERNEL_SRC
+    clock.c dmp.c floppy.c main.c memory.c printer.c proc.c system.c
+    table.c tty.c ${WINI_SRC})
+
+add_executable(kernel ${KERNEL_SRC})
+
+target_link_libraries(kernel PRIVATE minixlib)
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB LIB_SRC CONFIGURE_DEPENDS *.c)
+add_library(minixlib STATIC ${LIB_SRC})
+

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB MM_SRC *.c)
+add_executable(mm ${MM_SRC})
+target_link_libraries(mm PRIVATE minixlib)
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB TOOL_SRC *.c)
+foreach(src ${TOOL_SRC})
+  get_filename_component(prog ${src} NAME_WE)
+  set(target tool_${prog})
+  add_executable(${target} ${src})
+  target_link_libraries(${target} PRIVATE minixlib)
+endforeach()
+


### PR DESCRIPTION
## Summary
- add a root `CMakeLists.txt` with PC/AT driver option
- compile sources in `kernel`, `mm`, `fs`, `lib`, `tools`, and `commands`
- update the README with CMake build instructions

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: incompatible old-style C code)*