### PR TITLE
Add build convenience Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all:
+	cmake -B build -S .
+	cmake --build build
+
+clean:
+	rm -rf build
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ cmake -B build
 cmake --build build
 ```
 
+A simple root `Makefile` runs these commands as well, so you can just run `make` to build everything and `make clean` to remove the `build` directory.
+
 The kernel wini driver can be selected by passing `-DDRIVER_AT=ON` for the AT
 driver or `-DDRIVER_PC=ON` for the original PC/XT driver.  If neither option is
 specified the PC/XT driver is used.


### PR DESCRIPTION
## Summary
- add a simple root `Makefile` that calls CMake
- document the new Makefile usage in `README.md`

## Testing
- `cmake -B build -S .`
- `cmake --build build` *(fails: address of register variable requested)*