### PR TITLE
Add license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,47 @@
+MINIX License History
+=====================
+
+The original MINIX 1 sources (1987–2001) carried the following notice in
+`h/const.h` and related files:
+
+Copyright (C) 1987 by Prentice-Hall, Inc.
+Permission is hereby granted to private individuals and educational
+institutions to modify and redistribute the binary and source programs of
+this system to other private individuals and educational institutions for
+educational and research purposes.  For corporate or commercial use,
+permission from Prentice-Hall is required.  In general, such permission
+will be granted, subject to a few conditions.
+
+In May 2001 MINIX was relicensed under the BSD 3-Clause license, beginning
+with version 2.0.3.  The BSD license was retroactively applied to all
+previous versions as well.
+
+BSD 3-Clause License
+--------------------
+
+Copyright (c) 2001, Vrije Universiteit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the Vrije Universiteit nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ The kernel wini driver can be selected by passing `-DDRIVER_AT=ON` for the AT
 driver or `-DDRIVER_PC=ON` for the original PC/XT driver.  If neither option is
 specified the PC/XT driver is used.
 
+## License
+
+The historic Minix 1 sources were distributed under a permissive license from
+Prentice Hall allowing educational use and redistribution.  As of version 2.0.3
+(May 2001) the project adopted the BSD&nbsp;3-Clause license, retroactively
+applying it to all earlier releases.  See the [LICENSE](LICENSE) file for the
+full text.
+
 ## Documentation Note
 
 The repository originally included short `read_me` files under `doc` and `lib`.


### PR DESCRIPTION
## Summary
- add LICENSE file reflecting the historic Prentice Hall terms and the switch to BSD 3-Clause in 2001
- document license in README

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: address of register variable requested)*