### PR TITLE
Merge historical blurb and remove readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This repository contains the original sources of the Minix 1 operating system as
 released in 1987.  The tree is organized into the major components of the
 system such as the kernel, file system, libraries and user commands.
 
+Minix 1 was originally distributed as an appendix to Andrew S. Tanenbaum's
+book *Operating Systems: Design and Implementation*.  Providing a real
+operating system to accompany the text allowed students to explore the source
+while reading about its design.  This repository preserves that historical
+release.
+
 ## Build Requirements
 
 To compile the sources you need an ANSI C compiler, assembler and linker

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,0 @@
-Minix 1
-
-Andy Tanenbaum first released MINIX 1 in 1987 as an appendix to the book, Operating Systems: Design and Implementation


### PR DESCRIPTION
## Summary
- incorporate the contents of `readme.txt` into `README.md`
- delete the now redundant `readme.txt`

## Testing
- `cmake -B build`
- `cmake --build build -- -j$(nproc)` *(fails: address of register variable requested)*