### PR TITLE
Add assembly files to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(minix1 C)
+enable_language(ASM)
 
 # Options for wini driver selection
 option(DRIVER_AT "Use AT wini driver" OFF)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -9,7 +9,9 @@ set(KERNEL_SRC
     clock.c dmp.c floppy.c main.c memory.c printer.c proc.c system.c
     table.c tty.c ${WINI_SRC})
 
-add_executable(kernel ${KERNEL_SRC})
+file(GLOB KERNEL_ASM CONFIGURE_DEPENDS *.s *.asm)
+
+add_executable(kernel ${KERNEL_SRC} ${KERNEL_ASM})
 
 target_link_libraries(kernel PRIVATE minixlib)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
 file(GLOB LIB_SRC CONFIGURE_DEPENDS *.c)
-add_library(minixlib STATIC ${LIB_SRC})
+file(GLOB LIB_ASM CONFIGURE_DEPENDS *.s *.asm)
+add_library(minixlib STATIC ${LIB_SRC} ${LIB_ASM})
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,13 @@
 file(GLOB TOOL_SRC *.c)
+file(GLOB TOOL_ASM *.s *.asm)
 foreach(src ${TOOL_SRC})
+  get_filename_component(prog ${src} NAME_WE)
+  set(target tool_${prog})
+  add_executable(${target} ${src})
+  target_link_libraries(${target} PRIVATE minixlib)
+endforeach()
+
+foreach(src ${TOOL_ASM})
   get_filename_component(prog ${src} NAME_WE)
   set(target tool_${prog})
   add_executable(${target} ${src})


### PR DESCRIPTION
## Summary
- enable ASM language
- include `.s` and `.asm` sources in the library
- build assembly when compiling the kernel
- build assembly tools if present

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: crypt.c compilation error)*