### PR TITLE
Add CI step for running test programs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,9 @@ jobs:
       run: cmake -B build
     - name: Build
       run: cmake --build build -- -j$(nproc)
+    - name: Run sample tests
+      run: |
+        for t in $(sed '/^echo/d' test/run); do
+          make -C test f=$t
+          ./test/$t
+        done

--- a/lib/crypt.c
+++ b/lib/crypt.c
@@ -2,7 +2,7 @@ char *crypt(pw, salt)
 char *pw, *salt;
 {
 	static char buf[14];
-	register char bits[67];
+        char bits[67];
 	register int i;
 	register int j, rot;
 

--- a/test/test0.c
+++ b/test/test0.c
@@ -3,6 +3,7 @@ extern int errno;
 int errct;
 int testnr;
 extern long lseek();
+static void clraa();
 
 
 #define NB          30L


### PR DESCRIPTION
## Summary
- add a job step to compile and run the sample test programs
- modernize `crypt.c` for modern compilers
- make `clraa` prototype explicit in `test0.c`

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: static declaration errors)*
- `make -C test f=test0` *(fails: missing `../lib/libc.a`)*