### PR TITLE
Add basic 4-level paging and allocator

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -1,0 +1,46 @@
+#ifndef PAGING_H
+#define PAGING_H
+
+#include "../h/const.h"
+#include "../h/type.h"
+
+/* Generic 4-level paging structures for 48-bit virtual addresses. */
+
+#define PAGE_SIZE_4K       4096
+#define PT_ENTRIES         512
+
+/* Page table entry flags */
+#define PT_PRESENT   0x001
+#define PT_WRITABLE  0x002
+#define PT_USER      0x004
+
+typedef unsigned long long phys_addr64;
+typedef unsigned long long virt_addr64;
+
+struct pt_entry {
+    phys_addr64 addr;
+    unsigned long flags;
+};
+
+struct page_table {
+    struct pt_entry entries[PT_ENTRIES];
+};
+
+struct page_directory {
+    struct page_table *tables[PT_ENTRIES];
+};
+
+struct page_dir_ptr {
+    struct page_directory *dirs[PT_ENTRIES];
+};
+
+struct pml4 {
+    struct page_dir_ptr *ptrs[PT_ENTRIES];
+};
+
+/* Kernel interfaces */
+void paging_init(void);
+void *alloc_virtual(unsigned long long bytes, int flags);
+int map_page(virt_addr64 va, phys_addr64 pa, int flags);
+
+#endif /* PAGING_H */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -54,6 +54,7 @@ PUBLIC main()
    */
 
   lock();			/* we can't handle interrupts yet */
+  paging_init();                /* set up initial page tables */
   base_click = BASE >> CLICK_SHIFT;
   size = sizes[0] + sizes[1];	/* kernel text + data size in clicks */
   mm_base = base_click + size;	/* place where MM starts (in clicks) */

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -23,7 +23,7 @@ WINI_SRC = xt_wini.c
 endif
 
 obj = mpx88.o main.o proc.o system.o tty.o clock.o memory.o floppy.o wini.o  \
-      printer.o table.o klib88.o dmp.o 
+      printer.o table.o klib88.o dmp.o paging.o 
 
 kernel:	makefile $(obj) $l/libc.a
 	@echo "Start linking Kernel"
@@ -59,6 +59,7 @@ dmp.o:		$h/error.h
 dmp.o:		glo.h
 dmp.o:		proc.h
 
+paging.o:       const.h type.h ../include/paging.h
 main.o:		const.h type.h $h/const.h $h/type.h
 main.o:		$h/callnr.h
 main.o:		$h/com.h

--- a/kernel/paging.c
+++ b/kernel/paging.c
@@ -1,0 +1,38 @@
+#include "const.h"
+#include "type.h"
+#include "../include/paging.h"
+
+/* Simple 4-level page table allocator used only for illustration. */
+
+PRIVATE struct pml4 kernel_pml4;
+PRIVATE virt_addr64 next_kernel_va;
+
+PUBLIC void paging_init(void)
+{
+    int i;
+    for (i = 0; i < PT_ENTRIES; i++) kernel_pml4.ptrs[i] = NIL_PTR;
+    /* place kernel in higher half */
+    next_kernel_va = 0xffff800000000000ULL;
+}
+
+PUBLIC void *alloc_virtual(unsigned long long bytes, int flags)
+{
+    virt_addr64 va = next_kernel_va;
+    unsigned long pages = (bytes + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
+    next_kernel_va += pages * PAGE_SIZE_4K;
+    (void)flags; /* protection flags not modelled */
+    return (void *)va;
+}
+
+PUBLIC int map_page(virt_addr64 va, phys_addr64 pa, int flags)
+{
+    /* Mapping is not actually implemented.  We only preserve bookkeeping. */
+    unsigned idx4 = (va >> 39) & 0x1FF;
+    if (!kernel_pml4.ptrs[idx4]) {
+        kernel_pml4.ptrs[idx4] = (struct page_dir_ptr*) alloc_mem((sizeof(struct page_dir_ptr)+CLICK_SIZE-1)>>CLICK_SHIFT);
+        memset(kernel_pml4.ptrs[idx4], 0, sizeof(struct page_dir_ptr));
+    }
+    /* Further levels would be allocated here in a complete system. */
+    (void)pa; (void)flags;
+    return OK;
+}

--- a/kernel/system.c
+++ b/kernel/system.c
@@ -472,37 +472,13 @@ int proc_nr;			/* MM_PROC_NR or FS_PROC_NR */
  *				umap					     * 
  *===========================================================================*/
 PUBLIC phys_bytes umap(rp, seg, vir_addr, bytes)
-register struct proc *rp;	/* pointer to proc table entry for process */
-int seg;			/* T, D, or S segment */
-vir_bytes vir_addr;		/* virtual address in bytes within the seg */
-vir_bytes bytes;		/* # of bytes to be copied */
+register struct proc *rp;       /* unused with paging */
+int seg;                        /* ignored */
+vir_bytes vir_addr;             /* virtual address */
+vir_bytes bytes;                /* number of bytes */
 {
-/* Calculate the physical memory address for a given virtual address. */
-  vir_clicks vc;		/* the virtual address in clicks */
-  phys_bytes seg_base, pa;	/* intermediate variables as phys_bytes */
-
-  /* If 'seg' is D it could really be S and vice versa.  T really means T.
-   * If the virtual address falls in the gap,  it causes a problem. On the
-   * 8088 it is probably a legal stack reference, since "stackfaults" are
-   * not detected by the hardware.  On 8088s, the gap is called S and
-   * accepted, but on other machines it is called D and rejected.
-   */
-  if (bytes <= 0) return( (phys_bytes) 0);
-  vc = (vir_addr + bytes - 1) >> CLICK_SHIFT;	/* last click of data */
-
-#ifdef i8088
-  if (seg != T)
-	seg = (vc < rp->p_map[D].mem_vir + rp->p_map[D].mem_len ? D : S);
-#else
-  if (seg != T)
-	seg = (vc < rp->p_map[S].mem_vir ? D : S);
-#endif
-
-  if((vir_addr>>CLICK_SHIFT) >= rp->p_map[seg].mem_vir + rp->p_map[seg].mem_len)
-	return( (phys_bytes) 0 );
-  seg_base = (phys_bytes) rp->p_map[seg].mem_phys;
-  seg_base = seg_base << CLICK_SHIFT;	/* segment orgin in bytes */
-  pa = (phys_bytes) vir_addr;
-  pa -= rp->p_map[seg].mem_vir << CLICK_SHIFT;
-  return(seg_base + pa);
+/* Flat memory model: return virtual address as physical address. */
+    if (bytes <= 0) return (phys_bytes)0;
+    (void)rp; (void)seg;
+    return (phys_bytes)vir_addr;
 }

--- a/mm/main.c
+++ b/mm/main.c
@@ -116,6 +116,7 @@ PRIVATE mm_init()
    */
   tot_mem = get_tot_mem();	/* # clicks in mem starting at absolute 0 */
   mem_init(tot_mem);		/* initialize tables to all physical mem */
+  mm_paging_init();
 
   /* Initialize MM's tables. */
   mproc[MM_PROC_NR].mp_flags |= IN_USE;

--- a/mm/makefile
+++ b/mm/makefile
@@ -3,7 +3,7 @@ h=../h
 l=../lib
 
 obj =	main.o forkexit.o break.o exec.o signal.o getset.o  \
-	alloc.o utility.o table.o putc.o 
+	alloc.o utility.o table.o paging.o putc.o 
 
 mm:	makefile  $l/head.o $(obj) $l/libc.a $l/end.o
 	@echo "Start linking MM"
@@ -49,6 +49,7 @@ main.o:		$h/error.h
 main.o:		glo.h
 main.o:		mproc.h
 main.o:		param.h
+paging.o:       const.h ../include/paging.h
 
 putc.o:		$h/const.h $h/type.h
 putc.o:		$h/com.h

--- a/mm/paging.c
+++ b/mm/paging.c
@@ -1,0 +1,21 @@
+#include "const.h"
+#include "../include/paging.h"
+
+/* User space virtual address allocator using 4-level page tables. */
+
+PRIVATE virt_addr64 next_user_va;
+
+PUBLIC void mm_paging_init(void)
+{
+    /* start at low canonical address */
+    next_user_va = 0x0000000000400000ULL;
+}
+
+PUBLIC void *vm_alloc(unsigned long long bytes, int flags)
+{
+    virt_addr64 va = next_user_va;
+    unsigned long pages = (bytes + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
+    next_user_va += pages * PAGE_SIZE_4K;
+    (void)flags;
+    return (void *)va;
+}


### PR DESCRIPTION
## Summary
- add new `paging.h` with 4-level page table definitions
- implement stubbed kernel and user space paging allocators
- initialize paging in kernel and MM startup
- switch `umap()` to a flat model

## Testing
- `git status --short`