### PR TITLE
Enable basic 64-bit syscall path

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,6 +19,9 @@
 #include "type.h"
 #include "glo.h"
 #include "proc.h"
+#ifdef __x86_64__
+void init_syscall_msrs(void);
+#endif
 
 #define SAFETY             8	/* margin of safety for stack overflow (ints)*/
 #define VERY_BIG       39328	/* must be bigger than kernel size (clicks) */
@@ -127,9 +130,12 @@ PUBLIC main()
   set_vec(FLOPPY_VECTOR, disk_int, base_click);
   set_vec(PRINTER_VECTOR, lpr_int, base_click);
   if (pc_at)
-	  set_vec(AT_WINI_VECTOR, wini_int, base_click);
+          set_vec(AT_WINI_VECTOR, wini_int, base_click);
   else
-	  set_vec(XT_WINI_VECTOR, wini_int, base_click);
+          set_vec(XT_WINI_VECTOR, wini_int, base_click);
+#ifdef __x86_64__
+  init_syscall_msrs();
+#endif
 
   /* Put a ptr to proc table in a known place so it can be found in /dev/mem */
   set_vec( (BASE - 4)/4, proc, (phys_clicks) 0);

--- a/kernel/mpx88.s
+++ b/kernel/mpx88.s
@@ -85,14 +85,25 @@ M.1:	jmp M.1			| this should never be executed
 |*				s_call					     *
 |*===========================================================================*
 _s_call:			| System calls are vectored here.
-	call save		| save the machine state
-	mov bp,_proc_ptr	| use bp to access sys call parameters
-	push 2(bp)		| push(pointer to user message) (was bx)
-	push (bp)		| push(src/dest) (was ax)
-	push _cur_proc		| push caller
-	push 4(bp)		| push(SEND/RECEIVE/BOTH) (was cx)
-	call _sys_call		| sys_call(function, caller, src_dest, m_ptr)
-	jmp _restart		| jump to code to restart proc/task running
+#ifdef i8088
+        call save               | save the machine state
+        mov bp,_proc_ptr        | use bp to access sys call parameters
+        push 2(bp)              | push(pointer to user message) (was bx)
+        push (bp)               | push(src/dest) (was ax)
+        push _cur_proc          | push caller
+        push 4(bp)              | push(SEND/RECEIVE/BOTH) (was cx)
+        call _sys_call          | sys_call(function, caller, src_dest, m_ptr)
+        jmp _restart            | jump to code to restart proc/task running
+#else
+        call save
+        mov %rdi, %rax
+        mov %rdx, %rdi
+        mov _cur_proc(%rip), %esi
+        mov %rax, %rdx
+        mov %rsi, %rcx
+        call _sys_call
+        jmp _restart
+#endif
 
 
 |*===========================================================================*

--- a/kernel/syscall.s
+++ b/kernel/syscall.s
@@ -1,0 +1,34 @@
+#ifdef __x86_64__
+.text
+.global init_syscall_msrs
+.global syscall_entry
+
+init_syscall_msrs:
+    mov $0xC0000080, %ecx
+    rdmsr
+    or $1, %eax
+    wrmsr
+    mov $0xC0000081, %ecx
+    mov $(0x18 << 16) | 0x18, %eax
+    xor %edx, %edx
+    wrmsr
+    mov $0xC0000082, %ecx
+    mov $syscall_entry, %rax
+    wrmsr
+    mov $0xC0000084, %ecx
+    xor %eax, %eax
+    xor %edx, %edx
+    wrmsr
+    ret
+
+syscall_entry:
+    call save
+    mov %rdi, %rax
+    mov %rdx, %rdi
+    mov _cur_proc(%rip), %esi
+    mov %rax, %rdx
+    mov %rsi, %rcx
+    call _sys_call
+    jmp _restart
+#endif
+

--- a/lib/syscall_x86_64.c
+++ b/lib/syscall_x86_64.c
@@ -1,0 +1,35 @@
+#ifdef __x86_64__
+#include "../h/com.h"
+#include "../h/type.h"
+
+PUBLIC int send(int dst, message *m_ptr)
+{
+    register long rax asm("rax") = 0;
+    register long rdi asm("rdi") = dst;
+    register message *rsi asm("rsi") = m_ptr;
+    register long rdx asm("rdx") = SEND;
+    asm volatile ("syscall" : "=a"(rax) : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax) : "rcx", "r11", "memory");
+    return (int)rax;
+}
+
+PUBLIC int receive(int src, message *m_ptr)
+{
+    register long rax asm("rax") = 0;
+    register long rdi asm("rdi") = src;
+    register message *rsi asm("rsi") = m_ptr;
+    register long rdx asm("rdx") = RECEIVE;
+    asm volatile ("syscall" : "=a"(rax) : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax) : "rcx", "r11", "memory");
+    return (int)rax;
+}
+
+PUBLIC int sendrec(int srcdest, message *m_ptr)
+{
+    register long rax asm("rax") = 0;
+    register long rdi asm("rdi") = srcdest;
+    register message *rsi asm("rsi") = m_ptr;
+    register long rdx asm("rdx") = BOTH;
+    asm volatile ("syscall" : "=a"(rax) : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax) : "rcx", "r11", "memory");
+    return (int)rax;
+}
+#endif
+


### PR DESCRIPTION
## Summary
- configure SYSCALL MSRs on x86_64
- add x86_64 system call entry stub
- call SYSCALL setup from kernel `main`
- implement user‐level syscall wrappers using the x86_64 ABI
- update assembly for `_s_call` to use new registers

## Testing
- `make` *(fails: build errors in existing sources)*