### PR TITLE
Implement basic priority scheduler

### DIFF
--- a/kernel/const.h
+++ b/kernel/const.h
@@ -65,12 +65,23 @@
 
 #define RET_REG            0	/* system call return codes go in this reg */
 #define IDLE            -999	/* 'cur_proc' = IDLE means nobody is running */
+/* Scheduler configuration */
+#define SCHED_ROUND_ROBIN 0 /* set to 1 for simple round-robin */
 
-/* The following items pertain to the 3 scheduling queues. */
-#define NQ                 3	/* # of scheduling queues */
-#define TASK_Q             0	/* ready tasks are scheduled via queue 0 */
-#define SERVER_Q           1	/* ready servers are scheduled via queue 1 */
-#define USER_Q             2	/* ready users are scheduled via queue 2 */
+#if SCHED_ROUND_ROBIN
+#define NQ                 3    /* # of scheduling queues */
+#define TASK_Q             0    /* ready tasks are scheduled via queue 0 */
+#define SERVER_Q           1    /* ready servers are scheduled via queue 1 */
+#define USER_Q             2    /* ready users are scheduled via queue 2 */
+#define SCHED_QUEUES       NQ
+#else
+#define NR_SCHED_QUEUES   16    /* number of priority queues */
+#define PRI_TASK          0     /* task priority */
+#define PRI_SERVER        2     /* servers such as MM/FS */
+#define PRI_USER          8     /* default user process priority */
+#define SCHED_QUEUES      NR_SCHED_QUEUES
+#endif
+
 
 #define printf        printk	/* the kernel really uses printk, not printf */
 #endif

--- a/kernel/glo.h
+++ b/kernel/glo.h
@@ -13,6 +13,8 @@ EXTERN message int_mess;	/* interrupt routines build message here */
 /* CPU type. */
 EXTERN int olivetti;		/* TRUE for Olivetti-style keyboard */
 EXTERN int pc_at;		/*  PC-AT type diskette drives (360K/1.2M) ? */
+/* Current CPU id (for future SMP support) */
+EXTERN int current_cpu;
 
 /* The kernel and task stacks. */
 EXTERN struct t_stack {

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -75,8 +75,14 @@ PUBLIC main()
 		rp->p_splimit -= (TASK_STACK_BYTES - SAFETY)/sizeof(int);
 	rp->p_pcpsw.pc = task[t + NR_TASKS];
 	if (rp->p_pcpsw.pc != 0 || t >= 0) ready(rp);
-	rp->p_pcpsw.psw = INIT_PSW;
-	rp->p_flags = 0;
+        rp->p_pcpsw.psw = INIT_PSW;
+        rp->p_flags = 0;
+#if SCHED_ROUND_ROBIN
+        rp->p_priority = (t < 0 ? TASK_Q : t < LOW_USER ? SERVER_Q : USER_Q);
+#else
+        rp->p_priority = (t < 0 ? PRI_TASK : t < LOW_USER ? PRI_SERVER : PRI_USER);
+#endif
+        rp->p_cpu = 0;
 
 	/* Set up memory map for tasks and MM, FS, INIT. */
 	if (t < 0) {

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -39,6 +39,8 @@ EXTERN struct proc {
 #ifndef i8088
   uint64_t cr3;                 /* page table base */
 #endif
+  int p_priority;               /* scheduling priority */
+  int p_cpu;                    /* CPU affinity */
 } proc[NR_TASKS+NR_PROCS];
 
 /* Bits for p_flags in proc[].  A process is runnable iff p_flags == 0 */
@@ -52,8 +54,8 @@ EXTERN struct proc {
 
 EXTERN struct proc *proc_ptr;   /* &proc[cur_proc] */
 EXTERN struct proc *bill_ptr;   /* ptr to process to bill for clock ticks */
-EXTERN struct proc *rdy_head[NQ];       /* pointers to ready list headers */
-EXTERN struct proc *rdy_tail[NQ];       /* pointers to ready list tails */
+EXTERN struct proc *rdy_head[SCHED_QUEUES]; /* pointers to ready list headers */
+EXTERN struct proc *rdy_tail[SCHED_QUEUES]; /* pointers to ready list tails */
 
 EXTERN unsigned busy_map;               /* bit map of busy tasks */
 EXTERN message *task_mess[NR_TASKS+1];  /* ptrs to messages for busy tasks */


### PR DESCRIPTION
## Summary
- add scheduler configuration macros and priority constants
- track per-process priority and CPU affinity
- maintain ready queues using new priority scheduler
- initialize priority and CPU affinity in `main`

## Testing
- `make -C kernel proc.o` *(fails: TASK_STACK_BYTES undeclared)*