### PR TITLE
Add NASM replacements for boot utilities

### DIFF
--- a/tools/diskio.s
+++ b/tools/diskio.s
@@ -1,0 +1,55 @@
+[BITS 64]
+
+%define SECTOR_SIZE 512
+
+    global absread
+    global abswrite
+    global dmaoverr
+
+    extern pread
+    extern pwrite
+
+; ssize_t absread(int fd, uint64_t sector, void *buf)
+absread:
+    push rbp
+    mov rbp, rsp
+    ; rdi = fd, rsi = sector, rdx = buf
+    mov rcx, rsi            ; sector
+    shl rcx, 9              ; multiply by 512
+    mov rsi, rdx            ; buf pointer
+    mov rdx, SECTOR_SIZE    ; count
+    ; rdi already fd
+    call pread
+    cmp rax, SECTOR_SIZE
+    jne .error
+    xor eax, eax            ; return 0
+    pop rbp
+    ret
+.error:
+    mov eax, -1
+    pop rbp
+    ret
+
+; ssize_t abswrite(int fd, uint64_t sector, const void *buf)
+abswrite:
+    push rbp
+    mov rbp, rsp
+    mov rcx, rsi            ; sector
+    shl rcx, 9
+    mov rsi, rdx            ; buf pointer
+    mov rdx, SECTOR_SIZE
+    ; rdi already fd
+    call pwrite
+    cmp rax, SECTOR_SIZE
+    jne .error_w
+    xor eax, eax
+    pop rbp
+    ret
+.error_w:
+    mov eax, -1
+    pop rbp
+    ret
+
+dmaoverr:
+    xor eax, eax
+    ret

--- a/tools/fsck1.s
+++ b/tools/fsck1.s
@@ -1,134 +1,93 @@
-STACKSIZE = 8192
+[BITS 64]
 
-.globl _main, _exit, _edata, _end, _putc, _getc, _reset_diskette, _diskio
-.globl csv, cret, begtext, begdata, begbss
-.globl _cylsiz, _tracksiz, _drive
+    global _start
+    global putc
+    global getc
+    global reset_diskette
+    global diskio
 
-.text
-begtext:
-start:
-	mov	dx,bx		| bootblok puts # sectors/track in bx
-	xor	ax,ax
-	mov	bx,#_edata	| prepare to clear bss
-	mov	cx,#_end
-	sub	cx,bx
-	sar	cx,*1
-st.1:	mov	(bx),ax		| clear bss
-	add	bx,#2
-	loop	st.1
+    extern main
+    extern exit
+    extern putchar
+    extern getchar
+    extern pread
+    extern pwrite
+    extern lseek
 
-	mov	_tracksiz,dx	| dx (was bx) is # sectors/track
-	add	dx,dx
-	mov	_cylsiz,dx	| # sectors/cylinder
-	mov	sp,#kerstack+STACKSIZE
-	call	_main
-	mov	bx,ax		| put scan code for '=' in bx
-	cli
-	mov	dx,#0x60
-	mov	ds,dx
-	mov	es,dx
-	mov	ss,dx
-	jmpi	0,0x60		| jmp to kernel
+%define SECTOR_SIZE 512
 
-_exit:	mov	bx,_tracksiz
-	jmp	start
+_start:
+    xor edi, edi        ; argc = 0
+    xor esi, esi        ; argv = NULL
+    call main
+    mov edi, eax
+    jmp exit
 
+; void putc(int c)
+putc:
+    mov edi, edi        ; char in dil -> rdi already
+    call putchar
+    ret
 
-_putc:
-	xor	ax,ax
-	call	csv
-	movb	al,4(bp)	| al contains char to be printed
-	movb	ah,#14		| 14 = print char
-	movb	bl,*1		| foreground color
-	push	bp		| not preserved
-	int	0x10		| call BIOS VIDEO_IO
-	pop	bp
-	jmp	cret
+; int getc(void)
+getc:
+    call getchar
+    movzx eax, al
+    ret
 
-_getc:
-	xorb	ah,ah
-	int	0x16
-	ret
+; int reset_diskette(void) -- no-op
+reset_diskette:
+    xor eax, eax
+    ret
 
-_reset_diskette:
-	xor	ax,ax
-	call	csv
-	push	es		| not preserved
-	int	0x13		| call BIOS DISKETTE_IO
-	pop	es
-	jmp	cret
+; int diskio(int rw, unsigned long sector, void* buf, unsigned long count)
+diskio:
+    push rbp
+    mov rbp, rsp
+    ; args: rdi=rw, rsi=sector, rdx=buf, rcx=count
+    mov r8, rdi         ; save rw
+    mov r9, rcx         ; count
+    mov r10, rdx        ; buffer pointer
+    ; compute offset
+    mov rax, rsi
+    shl rax, 9
+    mov rsi, rax        ; offset
+    mov rdi, 0          ; fd 0 - rely on external open? not used
+    ; disk file descriptor is global 'drive', expect to be in external variable
+    ; we simply use drive as fd via external symbol
+    extern drive_fd
+    mov rdi, [rel drive_fd]
+    mov rdx, r9
+    imul rdx, SECTOR_SIZE
+    cmp r8, 0
+    je .readop
+.writeop:
+    mov rdi, [rel drive_fd]
+    mov rsi, r10
+    mov rdx, r9
+    imul rdx, SECTOR_SIZE
+    mov rcx, rax        ; offset
+    call pwrite
+    cmp rax, rdx
+    jne .err
+    xor eax, eax
+    jmp .done
+.readop:
+    mov rdi, [rel drive_fd]
+    mov rsi, r10
+    mov rdx, r9
+    imul rdx, SECTOR_SIZE
+    mov rcx, rax        ; offset
+    call pread
+    cmp rax, rdx
+    jne .err
+    xor eax, eax
+    jmp .done
+.err:
+    mov eax, -1
+.done:
+    pop rbp
+    ret
 
-
-| handle diskio(RW, sector_number, buffer, sector_count) call
-| Do not issue a BIOS call that crosses a track boundary
-_diskio:
-	xor	ax,ax
-	call	csv
-	mov	tmp1,#0		| tmp1 = # sectors actually transferred
-	mov	di,10(bp)	| di = # sectors to transfer
-	mov	tmp2,di		| di = # sectors to transfer
-d0:	mov	ax,6(bp)	| ax = sector number to start at
-	xor	dx,dx		| dx:ax is dividend
-	div	_cylsiz		| ax = cylinder, dx = sector within cylinder
-	movb	cl,ah		| cl = hi-order bits of cylinder
-	rorb	cl,#1		| BIOS expects hi bits in a funny place
-	rorb	cl,#1		| ditto
-	movb	ch,al		| cx = sector # in BIOS format
-	mov	ax,dx		| ax = sector offset within cylinder
-	xor	dx,dx		| dx:ax is dividend
-	div	_tracksiz	| ax = head, dx = sector
-	movb	dh,al		| dh = head
-	orb	cl,dl		| cl = 2 high-order cyl bits || sector
-	incb	cl		| BIOS counts sectors starting at 1
-	movb	dl,_drive	| dl = drive code (0-3 or 0x80 - 0x81)
-	mov	bx,8(bp)	| bx = address of buffer
-	movb	al,cl		| al = sector #
-	addb	al,10(bp)	| compute last sector
-	decb	al		| al = last sector to transfer
-	cmpb	al,_tracksiz	| see if last sector is on next track
-	jle	d1		| jump if last sector is on this track
-	mov	10(bp),#1	| transfer 1 sector at a time
-d1:	movb	ah,4(bp)	| ah = READING or WRITING
-	addb	ah,*2		| BIOS codes are 2 and 3, not 0 and 1
-	movb	al,10(bp)	| al = # sectors to transfer
-	mov	tmp,ax		| al is # sectors to read/write
-	push	es		| BIOS ruins es
-	int	0x13		| issue BIOS call
-	pop	es		| restore es
-	cmpb	ah,*0		| ah != 0 means BIOS detected error
-	jne	d2		| exit with error
-	mov	ax,tmp		| fetch count of sectors transferred
-	xorb	ah,ah		| count is in ax
-	add	tmp1,ax		| tmp1 accumulates sectors transferred
-	mov	si,tmp1		| are we done yet?
-	cmp	si,tmp2		| ditto
-	je	d2		| jump if done
-	inc	6(bp)		| next time around, start 1 sector higher
-	add	8(bp),#0x200	| move up in buffer by 512 bytes
-	jmp	d0
-d2:	jmp	cret
-
-csv:
-	pop	bx
-	push	bp
-	mov	bp,sp
-	push	di
-	push	si
-	sub	sp,ax
-	jmp	(bx)
-
-cret:
-	lea	sp,*-4(bp)
-	pop	si
-	pop	di
-	pop	bp
-	ret
-
-.data
-begdata:
-tmp:	.word 0
-tmp1:	.word 0
-tmp2:	.word 0
-.bss
-begbss:
-kerstack:	.zerow STACKSIZE/2	| kernel stack
+section .data
+    drive_fd dq 0

--- a/tools/makefile
+++ b/tools/makefile
@@ -25,11 +25,8 @@ init:	$l/libc.a init.o $l/head.o
 # diskette does not start out by printing 'Booting MINIX 1.0' the problem is
 # probably that you have not made a good boot block.
 bootblok:	bootblok.s
-	as bootblok.s
-	@strip a.out
-	@dd if=a.out of=bootblok bs=16w skip=1 count=16 2>/dev/null
-	@rm a.out
-	@echo bootblok done.
+	nasm -f bin -o bootblok bootblok.s
+	@echo bootblok done.
 
 build:	build.o
 	cc -o build build.o
@@ -41,12 +38,13 @@ mkfs:	mkfs.o
 mkfs.o:	mkfs.c
 	cc -c -O -DUNIX mkfs.c
 
-fsck:	fsck.o fsck1.o
-	@ld -o fsck  fsck1.o fsck.o $l/libc.a
-	@echo fsck done.
+fsck:	fsck.o fsck1.o diskio.o
+	ld -o fsck  fsck1.o fsck.o diskio.o $l/libc.a
+	@echo fsck done.
 fsck1.o:	fsck1.s
-	as -o fsck1.o fsck1.s
-
+	nasm -f elf64 -o fsck1.o fsck1.s
+diskio.o:	diskio.s
+	nasm -f elf64 -o diskio.o diskio.s
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces
 # appears in the image file just as the original does on the disk, except that


### PR DESCRIPTION
## Summary
- rewrite fsck1.s using 64‑bit NASM syntax
- add diskio.s NASM implementation
- assemble bootblok, fsck1, and diskio with nasm via tools makefile

## Testing
- `nasm -f elf64 tools/fsck1.s -o /tmp/fsck1.o`
- `nasm -f elf64 tools/diskio.s -o /tmp/diskio.o`
- `nasm -f bin tools/bootblok.s -o /tmp/bootblok` *(fails: `| operator may only be applied to scalar values`)*
- `make -C tools fsck` *(fails to compile fsck.c)*