### PR TITLE
Remove 8086 build paths

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,9 +5,9 @@ build environment works on a Unix-like host.
 
 ## Prerequisites
 
-The build requires GCC (version 9 or later recommended) and an assembler such as
-NASM 2.14 or YASM 1.3.  CMake 3.5 or newer is needed when using the CMake build
-system.
+A 64-bit x86 compiler toolchain is required.  GCC 9 or later and either NASM
+2.14 or YASM 1.3 are known to work.  CMake 3.5 or newer is needed when using the
+CMake build system.
 
 ## Building with Makefiles
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ release.
 
 ## Build Requirements
 
-To compile the sources you need an ANSI C compiler, assembler and linker
-suitable for the target architecture.  The code and makefiles assume a Unix
-like toolchain and environment.  Recent versions of GCC (9 or later) work well
-for building the C sources.  Either NASM 2.14 or YASM 1.3 can be used to
-assemble the few hand written assembly files.
+Building now requires a 64-bit x86 compiler toolchain.  Recent versions of GCC
+(9 or later) together with NASM 2.14 or YASM 1.3 work well for compiling the C
+and assembly sources.  Older 16-bit configurations are no longer supported.
 
 More details on building and verifying the project are available in
 `BUILDING.md`.

--- a/fs/main.c
+++ b/fs/main.c
@@ -182,26 +182,6 @@ PRIVATE buf_pool()
   buf[NR_BUFS - 1].b_next = NIL_BUF;
 
   /* Delete any buffers that span a 64K boundary. */
-#ifdef i8088
-  for (bp = &buf[0]; bp < &buf[NR_BUFS]; bp++) {
-	org = get_base() << CLICK_SHIFT;	/* phys addr where FS is */
-	low_off = (vir_bytes) bp->b_data;
-	high_off = low_off + BLOCK_SIZE - 1;
-	if (((org + low_off) & M64K) != ((org + high_off) & M64K)) {
-		if (bp == &buf[0]) {
-			front = &buf[1];
-			buf[1].b_prev = NIL_BUF;
-		} else if (bp == &buf[NR_BUFS - 1]) {
-			rear = &buf[NR_BUFS - 2];
-			buf[NR_BUFS - 2].b_next = NIL_BUF;
-		} else {
-			/* Delete a buffer in the middle. */
-			bp->b_prev->b_next = bp + 1;
-			bp->b_next->b_prev = bp - 1;
-		}
-	}
-  }
-#endif
 
   for (bp = &buf[0]; bp < &buf[NR_BUFS]; bp++) bp->b_hash = bp->b_next;
   buf_hash[NO_BLOCK & (NR_BUF_HASH - 1)] = front;

--- a/fs/minix/makefile
+++ b/fs/minix/makefile
@@ -1,4 +1,4 @@
-CFLAGS= -Di8088 -w -F -T.
+CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib
 

--- a/fs/minix/makefile.at
+++ b/fs/minix/makefile.at
@@ -1,4 +1,4 @@
-CFLAGS= -Di8088 -w -F -T.
+CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib
 

--- a/kernel/clock.c
+++ b/kernel/clock.c
@@ -221,7 +221,6 @@ PRIVATE accounting()
 }
 
 
-#ifdef i8088
 /*===========================================================================*
  *				init_clock				     *
  *===========================================================================*/
@@ -238,4 +237,3 @@ PRIVATE init_clock()
   port_out(TIMER0, low_byte);		/* load timer low byte */
   port_out(TIMER0, high_byte);		/* load timer high byte */
 }
-#endif

--- a/kernel/const.h
+++ b/kernel/const.h
@@ -1,40 +1,6 @@
 /* General constants used by the kernel. */
 
-#ifdef i8088
-/* p_reg contains: ax, bx, cx, dx, si, di, bp, es, ds, cs, ss in that order. */
-#define NR_REGS           11	/* number of general regs in each proc slot */
-#define INIT_PSW      0x0200	/* initial psw */
-#define INIT_SP (int*)0x0010	/* initial sp: 3 words pushed by kernel */
-
-/* The following values are used in the assembly code.  Do not change the
- * values of 'ES_REG', 'DS_REG', 'CS_REG', or 'SS_REG' without making the 
- * corresponding changes in the assembly code.
- */
-#define ES_REG             7	/* proc[i].p_reg[ESREG] is saved es */
-#define DS_REG             8	/* proc[i].p_reg[DSREG] is saved ds */
-#define CS_REG             9	/* proc[i].p_reg[CSREG] is saved cs */
-#define SS_REG            10	/* proc[i].p_reg[SSREG] is saved ss */
-
-#define VECTOR_BYTES     284	/* bytes of interrupt vectors to save */
-#define MEM_BYTES    655360L	/* memory size for /dev/mem */
-
-/* Interrupt vectors */
-#define DIVIDE_VECTOR      0	/* divide interrupt vector */
-#define CLOCK_VECTOR       8	/* clock interrupt vector */
-#define KEYBOARD_VECTOR    9	/* keyboard interrupt vector */
-#define XT_WINI_VECTOR	  13	/* xt winchester interrupt vector */
-#define FLOPPY_VECTOR     14	/* floppy disk interrupt vector */
-#define PRINTER_VECTOR    15	/* line printer interrupt vector */
-#define SYS_VECTOR        32	/* system calls are made with int SYSVEC */
-#define AT_WINI_VECTOR	 118	/* at winchester interrupt vector */
-
-/* The 8259A interrupt controller has to be re-enabled after each interrupt. */
-#define INT_CTL         0x20	/* I/O port for interrupt controller */
-#define INT_CTLMASK     0x21	/* setting bits in this port disables ints */
-#define INT2_CTL	0xA0	/* I/O port for second interrupt controller */
-#define INT2_MASK	0xA1	/* setting bits in this port disables ints */
-#define ENABLE          0x20	/* code used to re-enable after an interrupt */
-#else /* assume x86_64 */
+/* 64-bit configuration constants */
 /* Register order: rax, rbx, rcx, rdx, rsi, rdi, rbp, r8, r9, r10, r11, r12, r13, r14, r15 */
 #define NR_REGS           15
 #define INIT_PSW      0x0200
@@ -84,4 +50,3 @@
 
 
 #define printf        printk	/* the kernel really uses printk, not printf */
-#endif

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -1,7 +1,7 @@
 # The kernel directory contains PC/XT and AT wini driver sources.  Set the
 # `WINI_DRIVER` variable to `pc` or `at` when invoking `make` to select the
 # correct driver.  If not specified the PC/XT driver is used.
-CFLAGS = -Di8088 -O
+CFLAGS = -O
 h=../h
 l=../lib
 

--- a/kernel/minix/makefile
+++ b/kernel/minix/makefile
@@ -1,7 +1,7 @@
 # The kernel directory contains files xt_wini.c and at_wini.c.  Before running
 # make you must copy one of these to wini.c, depending on whether you have a
 # PC or an AT.  You must do this even if you do not have a hard disk..
-CFLAGS= -Di8088 -w -F -T.
+CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib
 

--- a/kernel/minix/makefile.at
+++ b/kernel/minix/makefile.at
@@ -1,4 +1,4 @@
-CFLAGS= -Di8088 -w -F -T.
+CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -34,10 +34,6 @@ message *m_ptr;			/* interrupt message to send to the task */
 
   int i, n, old_map, this_bit;
 
-#ifdef i8088
-  /* Re-enable the 8259A interrupt controller. */
-  port_out(INT_CTL, ENABLE);	/* this re-enables the 8259A controller chip */
-  if (pc_at) port_out(INT2_CTL, ENABLE);	/* re-enable second 8259A */
 #endif
 
   /* Try to send the interrupt message to the indicated task. */

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -6,21 +6,12 @@
  */
 
 EXTERN struct proc {
-#ifdef i8088
-  int p_reg[NR_REGS];           /* process' registers */
-  int *p_sp;                    /* stack pointer */
-#else
   uint64_t p_reg[NR_REGS];      /* process' registers */
   uint64_t p_sp;                /* stack pointer */
-#endif
   struct pc_psw p_pcpsw;        /* pc and psw as pushed by interrupt */
   int p_flags;                  /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
   struct mem_map p_map[NR_SEGS];/* memory map */
-#ifdef i8088
-  int *p_splimit;               /* lowest legal stack value */
-#else
   uint64_t p_splimit;           /* lowest legal stack value */
-#endif
   int p_pid;                    /* process id passed in from MM */
 
   real_time user_time;          /* user time in ticks */
@@ -36,9 +27,7 @@ EXTERN struct proc {
 
   struct proc *p_nextready;     /* pointer to next ready process */
   int p_pending;                /* bit map for pending signals 1-16 */
-#ifndef i8088
   uint64_t cr3;                 /* page table base */
-#endif
   int p_priority;               /* scheduling priority */
   int p_cpu;                    /* CPU affinity */
 } proc[NR_TASKS+NR_PROCS];

--- a/kernel/system.c
+++ b/kernel/system.c
@@ -176,13 +176,6 @@ message *m_ptr;			/* pointer to request message */
 	panic("bad call to sys_newmap (dst)", NO_NUM);
   phys_copy(src_phys, dst_phys, pn);
 
-#ifdef i8088
-  /* On 8088, set segment registers. */
-  rp->p_reg[CS_REG] = rp->p_map[T].mem_phys;	/* set cs */
-  rp->p_reg[DS_REG] = rp->p_map[D].mem_phys;	/* set ds */
-  rp->p_reg[SS_REG] = rp->p_map[D].mem_phys;	/* set ss */
-  rp->p_reg[ES_REG] = rp->p_map[D].mem_phys;	/* set es */
-#endif
 
   old_flags = rp->p_flags;	/* save the previous value of the flags */
   rp->p_flags &= ~NO_MAP;

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -393,7 +393,6 @@ char ch;			/* scan code for character that arrived */
 }
 
 
-#ifdef i8088
 /*===========================================================================*
  *				make_break				     *
  *===========================================================================*/
@@ -442,7 +441,6 @@ char ch;			/* scan code of key just struck or released */
   }
   return(0);
 }
-#endif
 
 
 /*===========================================================================*
@@ -759,7 +757,6 @@ long other;			/* used for IOCTL replies */
 /*****************************************************************************/
 /*****************************************************************************/
 
-#ifdef i8088
 /* Now begins the code and data for the device-dependent tty drivers. */
 
 /* Definitions used by the console driver. */

--- a/kernel/type.h
+++ b/kernel/type.h
@@ -4,19 +4,6 @@
  * trap or interrupt, as well as for causing interrupts for signals.
  */
 
-#ifdef i8088
-struct pc_psw {
-  int (*pc)();                  /* storage for program counter */
-  phys_clicks cs;               /* code segment register */
-  unsigned psw;                 /* program status word */
-};
-
-/* This struct is used to build data structure pushed by kernel upon signal. */
-struct sig_info {
-  int signo;                    /* sig number at end of stack */
-  struct pc_psw sigpcpsw;
-};
-#else /* assume x86_64 */
 #include <stdint.h>
 struct pc_psw {
   uint64_t rip;                 /* instruction pointer */
@@ -27,4 +14,3 @@ struct sig_info {
   int signo;
   struct pc_psw sigpcpsw;
 };
-#endif

--- a/mm/const.h
+++ b/mm/const.h
@@ -9,12 +9,10 @@
 #define MM_STACK_BYTES	MAX_ISTACK_BYTES + MAX_PATH + 384
 #endif
 
+#define PAGE_SIZE        4096
+#define MAX_PAGES      1048576
+#define HDR_SIZE           32
 #define NO_MEM (phys_clicks)0	/* returned by alloc_mem() with mem is up */
 
-#ifdef i8088
-#define PAGE_SIZE	  16	/* how many bytes in a page */
-#define MAX_PAGES       4096	/* how many pages in the virtual addr space */
-#define HDR_SIZE	  32	/* # bytes in the exec file header */
-#endif
 
 #define printf        printk

--- a/mm/forkexit.c
+++ b/mm/forkexit.c
@@ -55,9 +55,6 @@ PUBLIC int do_fork()
   /* Determine how much memory to allocate. */
   prog_clicks = (phys_clicks) rmp->mp_seg[T].mem_len + rmp->mp_seg[D].mem_len +
 						      rmp->mp_seg[S].mem_len;
-#ifdef i8088
-  prog_clicks += rmp->mp_seg[S].mem_vir - rmp->mp_seg[D].mem_len; /* gap too */
-#endif
   prog_bytes = (long) prog_clicks << CLICK_SHIFT;
   if ( (child_base = alloc_mem(prog_clicks)) == NO_MEM) return(EAGAIN);
 

--- a/mm/makefile
+++ b/mm/makefile
@@ -1,4 +1,4 @@
-CFLAGS= -Di8088 -O
+CFLAGS= -O
 h=../h
 l=../lib
 

--- a/mm/minix/makefile
+++ b/mm/minix/makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Di8088 -w -F -T.
+CFLAGS = -w -F -T.
 h=../h
 l=/usr/lib
 

--- a/mm/minix/makefile.at
+++ b/mm/minix/makefile.at
@@ -1,4 +1,4 @@
-CFLAGS = -Di8088 -w -F -T.
+CFLAGS = -w -F -T.
 h=../h
 l=/usr/lib
 

--- a/tools/minix/makefile
+++ b/tools/minix/makefile
@@ -45,7 +45,7 @@ fsck:	fsck.s fsck1.s
 	asld -o fsck  fsck1.s fsck.s $l/libc.a $l/end.s
 	@echo fsck done. Please restore /lib/cem manually.
 fsck.s: fsck.c
-	cc -c -Di8088 -w -F -T. fsck.c
+	cc -c -w -F -T. fsck.c
 
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces

--- a/tools/minix/makefile.at
+++ b/tools/minix/makefile.at
@@ -45,7 +45,7 @@ fsck:	fsck.s fsck1.s
 	asld -o fsck -T.  fsck1.s fsck.s $l/libc.a $l/end.s
 	@echo fsck done. 
 fsck.s: fsck.c
-	cc -c -Di8088 -w -F -T. fsck.c
+	cc -c -w -F -T. fsck.c
 
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces


### PR DESCRIPTION
## Summary
- strip `i8088` branches from headers and sources
- remove `-Di8088` from makefiles
- update docs for 64‑bit toolchain requirement

## Testing
- `make` *(fails: static declaration errors in library)*