### PR TITLE
Enable cross compilation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -32,6 +32,24 @@ cmake --build build
 You can select the AT or PC/XT wini driver using the options described in the
 `README.md` file.
 
+## Cross Compiling for x86_64
+
+The build can target a bare x86\_64 system using a cross toolchain.  Specify the
+tool prefix through the `CROSS_PREFIX` variable.  When invoking CMake directly
+pass `-DCROSS_COMPILE_X86_64=ON` along with the prefix:
+
+```sh
+cmake -B build -DCROSS_COMPILE_X86_64=ON -DCROSS_PREFIX=x86_64-elf-
+cmake --build build
+```
+
+The top-level `Makefile` accepts the same variable so the above commands can be
+simplified to:
+
+```sh
+make CROSS_PREFIX=x86_64-elf-
+```
+
 ## Testing the Build
 
 To quickly check that the toolchain works you can compile one of the sample

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,25 @@ project(minix1 C)
 enable_language(ASM_NASM)
 set(CMAKE_ASM_NASM_OBJECT_FORMAT elf64)
 
+# Optional cross compilation support for x86_64.
+option(CROSS_COMPILE_X86_64 "Cross compile for bare x86_64" OFF)
+set(CROSS_PREFIX "" CACHE STRING "Prefix for cross compilation tools")
+
+if(CROSS_COMPILE_X86_64)
+  # Configure compilers and tools using the provided prefix.
+  if(CROSS_PREFIX STREQUAL "")
+    set(CROSS_PREFIX "x86_64-elf-")
+  endif()
+  set(CMAKE_SYSTEM_NAME Generic)
+  set(CMAKE_SYSTEM_PROCESSOR x86_64)
+  set(CMAKE_C_COMPILER "${CROSS_PREFIX}gcc")
+  set(CMAKE_ASM_NASM_COMPILER "${CROSS_PREFIX}nasm")
+  set(CMAKE_AR "${CROSS_PREFIX}ar")
+  set(CMAKE_RANLIB "${CROSS_PREFIX}ranlib")
+  set(CMAKE_LINKER "${CROSS_PREFIX}ld")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+endif()
+
 # Options for wini driver selection
 option(DRIVER_AT "Use AT wini driver" OFF)
 option(DRIVER_PC "Use PC/XT wini driver" OFF)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ endif
 ifdef DRIVER_PC
 CMAKE_FLAGS += -DDRIVER_PC=$(DRIVER_PC)
 endif
+ifdef CROSS_PREFIX
+CMAKE_FLAGS += -DCROSS_COMPILE_X86_64=ON -DCROSS_PREFIX=$(CROSS_PREFIX)
+endif
 
 all:
 	cmake -B build -S . $(CMAKE_FLAGS)

--- a/lib/crt0.s
+++ b/lib/crt0.s
@@ -1,0 +1,22 @@
+# 64-bit startup code for cross-compiled programs
+# Provide _start entry, set up arguments and call _main.
+
+.globl _start, _main, _exit, _environ
+.text
+_start:
+    movq %rsp, %rdi          # rdi -> argc pointer
+    mov (%rdi), %edi         # edi = argc
+    lea 8(%rsp), %rsi        # rsi -> argv
+    lea 1(,%rdi,1), %rdx     # rdx = argc + 1
+    shl $3, %rdx             # convert to byte offset
+    add %rsi, %rdx           # rdx -> envp
+    mov %rdx, _environ(%rip) # store environ
+    call _main               # jump to main
+    mov %eax, %edi           # pass return code
+    call _exit               # exit process
+
+.data
+.globl _environ
+_environ:
+    .quad 0
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,8 @@ endforeach()
 foreach(src ${TOOL_ASM})
   get_filename_component(prog ${src} NAME_WE)
   set(target tool_${prog})
+  # Assembly only tools require the language hint.
+  set_source_files_properties(${src} PROPERTIES LANGUAGE ASM_NASM)
   add_executable(${target} ${src})
   target_link_libraries(${target} PRIVATE minixlib)
 endforeach()


### PR DESCRIPTION
## Summary
- add x86_64 cross build options in CMake
- support CROSS_PREFIX in Makefile
- provide 64‑bit startup file `crt0.s`
- hint CMake about assembly tools
- document cross-building in `BUILDING.md`

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: static declaration of `_printit` follows non-static)*