### PR TITLE
Add 64-bit fs size and extent skeleton

### DIFF
--- a/fs/compat.c
+++ b/fs/compat.c
@@ -1,0 +1,26 @@
+/* Translation helpers for compatibility with the original Minix FS.
+ * These helpers store 64-bit file sizes and extent tables while
+ * maintaining the legacy 32-bit structures.
+ */
+
+#include "compat.h"
+#include "../h/const.h"
+#include "../h/type.h"
+#include "extent.h"
+#include "inode.h"
+
+/* Initialize extended inode fields. */
+PUBLIC void init_extended_inode(struct inode *ip) {
+  ip->i_size64 = ip->i_size;
+  ip->i_extents = NIL_PTR;
+  ip->i_extent_count = 0;
+}
+
+/* Allocate extent table for an inode. Placeholder for real allocator. */
+PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count) {
+  /* Allocation is not implemented; ensure fields reflect failure. */
+  ip->i_extents = NIL_PTR;
+  ip->i_extent_count = 0;
+  (void)count;
+  return ENOSYS;
+}

--- a/fs/compat.h
+++ b/fs/compat.h
@@ -1,0 +1,25 @@
+/* Compatibility layer for legacy Minix file system structures. */
+#ifndef FS_COMPAT_H
+#define FS_COMPAT_H
+
+#include "extent.h"
+#include "inode.h"
+
+/* Retrieve the 64-bit size of an inode. */
+static inline file_pos64 compat_get_size(const struct inode *ip) {
+  return ip->i_size64 ? ip->i_size64 : (file_pos64)ip->i_size;
+}
+
+/* Update both 64-bit and 32-bit size fields. */
+static inline void compat_set_size(struct inode *ip, file_pos64 sz) {
+  ip->i_size64 = sz;
+  ip->i_size = (file_pos)sz;
+}
+
+/* Initialize extended fields of an inode. */
+PUBLIC void init_extended_inode(struct inode *ip);
+
+/* Allocate an extent table. */
+PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count);
+
+#endif /* FS_COMPAT_H */

--- a/fs/extent.h
+++ b/fs/extent.h
@@ -1,0 +1,15 @@
+/* Extent-based allocation structures. */
+#ifndef FS_EXTENT_H
+#define FS_EXTENT_H
+
+#include "../h/type.h"
+
+/* An extent describes a contiguous range of zones on disk. */
+typedef struct {
+  zone_nr e_start; /* first zone in the extent */
+  zone_nr e_count; /* number of zones in the extent */
+} extent;
+
+#define NIL_EXTENT (extent *)0
+
+#endif /* FS_EXTENT_H */

--- a/fs/inode.c
+++ b/fs/inode.c
@@ -12,82 +12,86 @@
  *   dup_inode:	  indicate that someone else is using an inode table entry
  */
 
+#include "inode.h"
 #include "../h/const.h"
-#include "../h/type.h"
 #include "../h/error.h"
-#include "const.h"
-#include "type.h"
+#include "../h/type.h"
 #include "buf.h"
+#include "compat.h"
+#include "const.h"
+#include "extent.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
-#include "inode.h"
 #include "super.h"
+#include "type.h"
 
 /*===========================================================================*
  *				get_inode				     *
  *===========================================================================*/
 PUBLIC struct inode *get_inode(dev, numb)
-dev_nr dev;			/* device on which inode resides */
-inode_nr numb;			/* inode number */
+dev_nr dev;    /* device on which inode resides */
+inode_nr numb; /* inode number */
 {
-/* Find a slot in the inode table, load the specified inode into it, and
- * return a pointer to the slot.  If 'dev' == NO_DEV, just return a free slot.
- */
+  /* Find a slot in the inode table, load the specified inode into it, and
+   * return a pointer to the slot.  If 'dev' == NO_DEV, just return a free slot.
+   */
 
   register struct inode *rip, *xp;
 
   /* Search the inode table both for (dev, numb) and a free slot. */
   xp = NIL_INODE;
   for (rip = &inode[0]; rip < &inode[NR_INODES]; rip++) {
-	if (rip->i_count > 0) { /* only check used slots for (dev, numb) */
-		if (rip->i_dev == dev && rip->i_num == numb) {
-			/* This is the inode that we are looking for. */
-			rip->i_count++;
-			return(rip);	/* (dev, numb) found */
-		}
-	} else
-		xp = rip;	/* remember this free slot for later */
+    if (rip->i_count > 0) { /* only check used slots for (dev, numb) */
+      if (rip->i_dev == dev && rip->i_num == numb) {
+        /* This is the inode that we are looking for. */
+        rip->i_count++;
+        return (rip); /* (dev, numb) found */
+      }
+    } else
+      xp = rip; /* remember this free slot for later */
   }
 
   /* Inode we want is not currently in use.  Did we find a free slot? */
-  if (xp == NIL_INODE) {	/* inode table completely full */
-	err_code = ENFILE;
-	return(NIL_INODE);
+  if (xp == NIL_INODE) { /* inode table completely full */
+    err_code = ENFILE;
+    return (NIL_INODE);
   }
 
   /* A free inode slot has been located.  Load the inode into it. */
   xp->i_dev = dev;
   xp->i_num = numb;
   xp->i_count = 1;
-  if (dev != NO_DEV) rw_inode(xp, READING);	/* get inode from disk */
+  if (dev != NO_DEV)
+    rw_inode(xp, READING); /* get inode from disk */
 
-  return(xp);
+  return (xp);
 }
-
 
 /*===========================================================================*
  *				put_inode				     *
  *===========================================================================*/
 PUBLIC put_inode(rip)
-register struct inode *rip;	/* pointer to inode to be released */
+register struct inode *rip; /* pointer to inode to be released */
 {
-/* The caller is no longer using this inode.  If no one else is using it either
- * write it back to the disk immediately.  If it has no links, truncate it and
- * return it to the pool of available inodes.
- */
+  /* The caller is no longer using this inode.  If no one else is using it
+   * either write it back to the disk immediately.  If it has no links, truncate
+   * it and return it to the pool of available inodes.
+   */
 
-  if (rip == NIL_INODE) return;	/* checking here is easier than in caller */
-  if (--rip->i_count == 0) {	/* i_count == 0 means no one is using it now */
-	if ((rip->i_nlinks & BYTE) == 0) {
-		/* i_nlinks == 0 means free the inode. */
-		truncate(rip);	/* return all the disk blocks */
-		rip->i_mode = I_NOT_ALLOC;	/* clear I_TYPE field */
-		rip->i_pipe = NO_PIPE;
-		free_inode(rip->i_dev, rip->i_num);
-	}
+  if (rip == NIL_INODE)
+    return;                  /* checking here is easier than in caller */
+  if (--rip->i_count == 0) { /* i_count == 0 means no one is using it now */
+    if ((rip->i_nlinks & BYTE) == 0) {
+      /* i_nlinks == 0 means free the inode. */
+      truncate(rip);             /* return all the disk blocks */
+      rip->i_mode = I_NOT_ALLOC; /* clear I_TYPE field */
+      rip->i_pipe = NO_PIPE;
+      free_inode(rip->i_dev, rip->i_num);
+    }
 
-	if (rip->i_dirt == DIRTY) rw_inode(rip, WRITING);
+    if (rip->i_dirt == DIRTY)
+      rw_inode(rip, WRITING);
   }
 }
 
@@ -95,10 +99,10 @@ register struct inode *rip;	/* pointer to inode to be released */
  *				alloc_inode				     *
  *===========================================================================*/
 PUBLIC struct inode *alloc_inode(dev, bits)
-dev_nr dev;			/* device on which to allocate the inode */
-mask_bits bits;			/* mode of the inode */
+dev_nr dev;     /* device on which to allocate the inode */
+mask_bits bits; /* mode of the inode */
 {
-/* Allocate a free inode on 'dev', and return a pointer to it. */
+  /* Allocate a free inode on 'dev', and return a pointer to it. */
 
   register struct inode *rip;
   register struct super_block *sp;
@@ -110,91 +114,94 @@ mask_bits bits;			/* mode of the inode */
   extern struct super_block *get_super();
 
   /* Acquire an inode from the bit map. */
-  sp = get_super(dev);		/* get pointer to super_block */
-  b=alloc_bit(sp->s_imap, (bit_nr)sp->s_ninodes+1, sp->s_imap_blocks,(bit_nr)0);
+  sp = get_super(dev); /* get pointer to super_block */
+  b = alloc_bit(sp->s_imap, (bit_nr)sp->s_ninodes + 1, sp->s_imap_blocks,
+                (bit_nr)0);
   if (b == NO_BIT) {
-	err_code = ENFILE;
-	major = (int) (sp->s_dev >> MAJOR) & BYTE;
-	minor = (int) (sp->s_dev >> MINOR) & BYTE;
-	if (sp->s_dev == ROOT_DEV)
-		printf("Out of i-nodes on root device (RAM disk)\n");
-	else
-		printf("Out of i-nodes on device %d/%d\n", major, minor);
-	return(NIL_INODE);
+    err_code = ENFILE;
+    major = (int)(sp->s_dev >> MAJOR) & BYTE;
+    minor = (int)(sp->s_dev >> MINOR) & BYTE;
+    if (sp->s_dev == ROOT_DEV)
+      printf("Out of i-nodes on root device (RAM disk)\n");
+    else
+      printf("Out of i-nodes on device %d/%d\n", major, minor);
+    return (NIL_INODE);
   }
-  numb = (inode_nr) b;
+  numb = (inode_nr)b;
 
   /* Try to acquire a slot in the inode table. */
-  if ( (rip = get_inode(NO_DEV, numb)) == NIL_INODE) {
-	/* No inode table slots available.  Free the inode just allocated. */
-	free_bit(sp->s_imap, b);
+  if ((rip = get_inode(NO_DEV, numb)) == NIL_INODE) {
+    /* No inode table slots available.  Free the inode just allocated. */
+    free_bit(sp->s_imap, b);
   } else {
-	/* An inode slot is available.  Put the inode just allocated into it. */
-	rip->i_mode = bits;
-	rip->i_nlinks = (links) 0;
-	rip->i_uid = fp->fp_effuid;
-	rip->i_gid = fp->fp_effgid;
-	rip->i_dev = dev;	/* was provisionally set to NO_DEV */
+    /* An inode slot is available.  Put the inode just allocated into it. */
+    rip->i_mode = bits;
+    rip->i_nlinks = (links)0;
+    rip->i_uid = fp->fp_effuid;
+    rip->i_gid = fp->fp_effgid;
+    rip->i_dev = dev; /* was provisionally set to NO_DEV */
 
-	/* The fields not cleared already are cleared in wipe_inode().  They have
-	 * been put there because truncate() needs to clear the same fields if
-	 * the file happens to be open while being truncated.  It saves space
-	 * not to repeat the code twice.
-	 */
-	wipe_inode(rip);
+    /* The fields not cleared already are cleared in wipe_inode().  They have
+     * been put there because truncate() needs to clear the same fields if
+     * the file happens to be open while being truncated.  It saves space
+     * not to repeat the code twice.
+     */
+    wipe_inode(rip);
+    init_extended_inode(rip);
   }
 
-  return(rip);
+  return (rip);
 }
 
 /*===========================================================================*
  *				wipe_inode				     *
  *===========================================================================*/
 PUBLIC wipe_inode(rip)
-register struct inode *rip;	/* The inode to be erased. */
+register struct inode *rip; /* The inode to be erased. */
 {
-/* Erase some fields in the inode.  This function is called from alloc_inode()
- * when a new inode is to be allocated, and from truncate(), when an existing
- * inode is to be truncated.
- */
+  /* Erase some fields in the inode.  This function is called from alloc_inode()
+   * when a new inode is to be allocated, and from truncate(), when an existing
+   * inode is to be truncated.
+   */
 
   register int i;
   extern real_time clock_time();
 
   rip->i_size = 0;
+  rip->i_size64 = 0;
+  rip->i_extents = NIL_EXTENT;
+  rip->i_extent_count = 0;
   rip->i_modtime = clock_time();
   rip->i_dirt = DIRTY;
   for (i = 0; i < NR_ZONE_NUMS; i++)
-	rip->i_zone[i] = NO_ZONE;
+    rip->i_zone[i] = NO_ZONE;
 }
-
 
 /*===========================================================================*
  *				free_inode				     *
  *===========================================================================*/
 PUBLIC free_inode(dev, numb)
-dev_nr dev;			/* on which device is the inode */
-inode_nr numb;			/* number of inode to be freed */
+dev_nr dev;    /* on which device is the inode */
+inode_nr numb; /* number of inode to be freed */
 {
-/* Return an inode to the pool of unallocated inodes. */
+  /* Return an inode to the pool of unallocated inodes. */
 
   register struct super_block *sp;
   extern struct super_block *get_super();
 
   /* Locate the appropriate super_block. */
   sp = get_super(dev);
-  free_bit(sp->s_imap, (bit_nr) numb);
+  free_bit(sp->s_imap, (bit_nr)numb);
 }
-
 
 /*===========================================================================*
  *				rw_inode				     *
  *===========================================================================*/
 PUBLIC rw_inode(rip, rw_flag)
-register struct inode *rip;	/* pointer to inode to be read/written */
-int rw_flag;			/* READING or WRITING */
+register struct inode *rip; /* pointer to inode to be read/written */
+int rw_flag;                /* READING or WRITING */
 {
-/* An entry in the inode table is to be copied to or from the disk. */
+  /* An entry in the inode table is to be copied to or from the disk. */
 
   register struct buf *bp;
   register d_inode *dip;
@@ -205,33 +212,32 @@ int rw_flag;			/* READING or WRITING */
 
   /* Get the block where the inode resides. */
   sp = get_super(rip->i_dev);
-  b = (block_nr) (rip->i_num - 1)/INODES_PER_BLOCK +
-				sp->s_imap_blocks + sp->s_zmap_blocks + 2;
+  b = (block_nr)(rip->i_num - 1) / INODES_PER_BLOCK + sp->s_imap_blocks +
+      sp->s_zmap_blocks + 2;
   bp = get_block(rip->i_dev, b, NORMAL);
   dip = bp->b_inode + (rip->i_num - 1) % INODES_PER_BLOCK;
 
   /* Do the read or write. */
   if (rw_flag == READING) {
-	copy((char *)rip, (char *) dip, INODE_SIZE); /* copy from blk to inode */
+    copy((char *)rip, (char *)dip, INODE_SIZE); /* copy from blk to inode */
   } else {
-	copy((char *)dip, (char *) rip, INODE_SIZE); /* copy from inode to blk */
-	bp->b_dirt = DIRTY;
+    copy((char *)dip, (char *)rip, INODE_SIZE); /* copy from inode to blk */
+    bp->b_dirt = DIRTY;
   }
 
   put_block(bp, INODE_BLOCK);
   rip->i_dirt = CLEAN;
 }
 
-
 /*===========================================================================*
  *				dup_inode				     *
  *===========================================================================*/
 PUBLIC dup_inode(ip)
-struct inode *ip;		/* The inode to be duplicated. */
+struct inode *ip; /* The inode to be duplicated. */
 {
-/* This routine is a simplified form of get_inode() for the case where
- * the inode pointer is already known.
- */
+  /* This routine is a simplified form of get_inode() for the case where
+   * the inode pointer is already known.
+   */
 
   ip->i_count++;
 }

--- a/fs/inode.h
+++ b/fs/inode.h
@@ -7,32 +7,35 @@
  * The disk inode part is also declared in "type.h" as 'd_inode'.
  */
 
+#include "extent.h"
 EXTERN struct inode {
-  unshort i_mode;		/* file type, protection, etc. */
-  uid i_uid;			/* user id of the file's owner */
-  file_pos i_size;		/* current file size in bytes */
-  real_time i_modtime;		/* when was file data last changed */
-  gid i_gid;			/* group number */
-  links i_nlinks;		/* how many links to this file */
-  zone_nr i_zone[NR_ZONE_NUMS];	/* zone numbers for direct, ind, and dbl ind */
+  unshort i_mode;                /* file type, protection, etc. */
+  uid i_uid;                     /* user id of the file's owner */
+  file_pos i_size;               /* current file size in bytes */
+  file_pos64 i_size64;           /* 64-bit file size */
+  extent *i_extents;             /* extent table for extent-based files */
+  unsigned short i_extent_count; /* number of extents */
+  real_time i_modtime;           /* when was file data last changed */
+  gid i_gid;                     /* group number */
+  links i_nlinks;                /* how many links to this file */
+  zone_nr i_zone[NR_ZONE_NUMS];  /* zone numbers for direct, ind, and dbl ind */
 
   /* The following items are not present on the disk. */
-  dev_nr i_dev;			/* which device is the inode on */
-  inode_nr i_num;		/* inode number on its (minor) device */
-  short int i_count;		/* # times inode used; 0 means slot is free */
-  char i_dirt;			/* CLEAN or DIRTY */
-  char i_pipe;			/* set to I_PIPE if pipe */
-  char i_mount;			/* this bit is set if file mounted on */
-  char i_seek;			/* set on LSEEK, cleared on READ/WRITE */
+  dev_nr i_dev;      /* which device is the inode on */
+  inode_nr i_num;    /* inode number on its (minor) device */
+  short int i_count; /* # times inode used; 0 means slot is free */
+  char i_dirt;       /* CLEAN or DIRTY */
+  char i_pipe;       /* set to I_PIPE if pipe */
+  char i_mount;      /* this bit is set if file mounted on */
+  char i_seek;       /* set on LSEEK, cleared on READ/WRITE */
 } inode[NR_INODES];
 
-
-#define NIL_INODE (struct inode *) 0	/* indicates absence of inode slot */
+#define NIL_INODE (struct inode *)0 /* indicates absence of inode slot */
 
 /* Field values.  Note that CLEAN and DIRTY are defined in "const.h" */
-#define NO_PIPE            0	/* i_pipe is NO_PIPE if inode is not a pipe */
-#define I_PIPE             1	/* i_pipe is I_PIPE if inode is a pipe */
-#define NO_MOUNT           0	/* i_mount is NO_MOUNT if file not mounted on */
-#define I_MOUNT            1	/* i_mount is I_MOUNT if file mounted on */
-#define NO_SEEK            0	/* i_seek = NO_SEEK if last op was not SEEK */
-#define ISEEK              1	/* i_seek = ISEEK if last op was SEEK */
+#define NO_PIPE 0  /* i_pipe is NO_PIPE if inode is not a pipe */
+#define I_PIPE 1   /* i_pipe is I_PIPE if inode is a pipe */
+#define NO_MOUNT 0 /* i_mount is NO_MOUNT if file not mounted on */
+#define I_MOUNT 1  /* i_mount is I_MOUNT if file mounted on */
+#define NO_SEEK 0  /* i_seek = NO_SEEK if last op was not SEEK */
+#define ISEEK 1    /* i_seek = ISEEK if last op was SEEK */

--- a/fs/link.c
+++ b/fs/link.c
@@ -9,23 +9,23 @@
  */
 
 #include "../h/const.h"
-#include "../h/type.h"
 #include "../h/error.h"
-#include "const.h"
-#include "type.h"
+#include "../h/type.h"
 #include "buf.h"
+#include "compat.h"
+#include "const.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "param.h"
+#include "type.h"
 
 /*===========================================================================*
  *				do_link					     *
  *===========================================================================*/
-PUBLIC int do_link()
-{
-/* Perform the link(name, name2) system call. */
+PUBLIC int do_link() {
+  /* Perform the link(name, name2) system call. */
 
   register struct inode *ip, *rip;
   register int r;
@@ -34,65 +34,71 @@ PUBLIC int do_link()
   extern struct inode *advance(), *last_dir(), *eat_path();
 
   /* See if 'name' (file to be linked) exists. */
-  if (fetch_name(name1, name1_length, M1) != OK) return(err_code);
-  if ( (rip = eat_path(user_path)) == NIL_INODE) return(err_code);
+  if (fetch_name(name1, name1_length, M1) != OK)
+    return (err_code);
+  if ((rip = eat_path(user_path)) == NIL_INODE)
+    return (err_code);
 
   /* Check to see if the file has maximum number of links already. */
   r = OK;
-  if ( (rip->i_nlinks & BYTE) == MAX_LINKS) r = EMLINK;
+  if ((rip->i_nlinks & BYTE) == MAX_LINKS)
+    r = EMLINK;
 
   /* Only super_user may link to directories. */
   if (r == OK)
-	if ( (rip->i_mode & I_TYPE) == I_DIRECTORY && !super_user) r = EPERM;
+    if ((rip->i_mode & I_TYPE) == I_DIRECTORY && !super_user)
+      r = EPERM;
 
   /* If error with 'name', return the inode. */
   if (r != OK) {
-	put_inode(rip);
-	return(r);
+    put_inode(rip);
+    return (r);
   }
 
   /* Does the final directory of 'name2' exist? */
-  if (fetch_name(name2, name2_length, M1) != OK) return(err_code);
-  if ( (ip = last_dir(user_path, string)) == NIL_INODE) r = err_code;
+  if (fetch_name(name2, name2_length, M1) != OK)
+    return (err_code);
+  if ((ip = last_dir(user_path, string)) == NIL_INODE)
+    r = err_code;
 
   /* If 'name2' exists in full (even if no space) set 'r' to error. */
   if (r == OK) {
-	if ( (new_ip = advance(ip, string)) == NIL_INODE) {
-		r = err_code;
-		if (r == ENOENT) r = OK;
-	} else {
-		put_inode(new_ip);
-		r = EEXIST;
-	}
+    if ((new_ip = advance(ip, string)) == NIL_INODE) {
+      r = err_code;
+      if (r == ENOENT)
+        r = OK;
+    } else {
+      put_inode(new_ip);
+      r = EEXIST;
+    }
   }
 
   /* Check for links across devices. */
   if (r == OK)
-	if (rip->i_dev != ip->i_dev) r = EXDEV;
+    if (rip->i_dev != ip->i_dev)
+      r = EXDEV;
 
   /* Try to link. */
   if (r == OK)
-	r = search_dir(ip, string, &rip->i_num, ENTER);
+    r = search_dir(ip, string, &rip->i_num, ENTER);
 
   /* If success, register the linking. */
   if (r == OK) {
-	rip->i_nlinks++;
-	rip->i_dirt = DIRTY;
+    rip->i_nlinks++;
+    rip->i_dirt = DIRTY;
   }
 
   /* Done.  Release both inodes. */
   put_inode(rip);
   put_inode(ip);
-  return(r);
+  return (r);
 }
-
 
 /*===========================================================================*
  *				do_unlink				     *
  *===========================================================================*/
-PUBLIC int do_unlink()
-{
-/* Perform the unlink(name) system call. */
+PUBLIC int do_unlink() {
+  /* Perform the unlink(name) system call. */
 
   register struct inode *rip, *rlast_dir_ptr;
   register int r;
@@ -101,45 +107,46 @@ PUBLIC int do_unlink()
   extern struct inode *advance(), *last_dir();
 
   /* Get the last directory in the path. */
-  if (fetch_name(name, name_length, M3) != OK) return(err_code);
-  if ( (rlast_dir_ptr = last_dir(user_path, string)) == NIL_INODE)
-	return(err_code);
+  if (fetch_name(name, name_length, M3) != OK)
+    return (err_code);
+  if ((rlast_dir_ptr = last_dir(user_path, string)) == NIL_INODE)
+    return (err_code);
 
   /* The last directory exists.  Does the file also exist? */
   r = OK;
-  if ( (rip = advance(rlast_dir_ptr, string)) == NIL_INODE) r = err_code;
+  if ((rip = advance(rlast_dir_ptr, string)) == NIL_INODE)
+    r = err_code;
 
   /* If error, return inode. */
   if (r != OK) {
-	put_inode(rlast_dir_ptr);
-	return(r);
+    put_inode(rlast_dir_ptr);
+    return (r);
   }
 
   /* See if the file is a directory. */
-  if ( (rip->i_mode & I_TYPE) == I_DIRECTORY && !super_user)
-	r = EPERM;		 /* only super_user can unlink directory */
+  if ((rip->i_mode & I_TYPE) == I_DIRECTORY && !super_user)
+    r = EPERM; /* only super_user can unlink directory */
   if (r == OK)
-	r = search_dir(rlast_dir_ptr, string, &numb, DELETE);
+    r = search_dir(rlast_dir_ptr, string, &numb, DELETE);
 
   if (r == OK) {
-	rip->i_nlinks--;
-	rip->i_dirt = DIRTY;
+    rip->i_nlinks--;
+    rip->i_dirt = DIRTY;
   }
 
   /* If unlink was possible, it has been done, otherwise it has not. */
   put_inode(rip);
   put_inode(rlast_dir_ptr);
-  return(r);
+  return (r);
 }
-
 
 /*===========================================================================*
  *				truncate				     *
  *===========================================================================*/
 PUBLIC truncate(rip)
-register struct inode *rip;	/* pointer to inode to be truncated */
+register struct inode *rip; /* pointer to inode to be truncated */
 {
-/* Remove all the zones from the inode 'rip' and mark it dirty. */
+  /* Remove all the zones from the inode 'rip' and mark it dirty. */
 
   register file_pos position;
   register zone_type zone_size;
@@ -151,31 +158,32 @@ register struct inode *rip;	/* pointer to inode to be truncated */
   extern struct buf *get_block();
   extern block_nr read_map();
 
-  dev = rip->i_dev;		/* device on which inode resides */
+  dev = rip->i_dev; /* device on which inode resides */
   scale = scale_factor(rip);
-  zone_size = (zone_type) BLOCK_SIZE << scale;
-  if (rip->i_pipe == I_PIPE) rip->i_size = PIPE_SIZE;	/* pipes can shrink */
+  zone_size = (zone_type)BLOCK_SIZE << scale;
+  if (rip->i_pipe == I_PIPE)
+    compat_set_size(rip, PIPE_SIZE); /* pipes can shrink */
 
   /* Step through the file a zone at a time, finding and freeing the zones. */
-  for (position = 0; position < rip->i_size; position += zone_size) {
-	if ( (b = read_map(rip, position)) != NO_BLOCK) {
-		z = (zone_nr) b >> scale;
-		free_zone(dev, z);
-	}
+  for (position = 0; position < compat_get_size(rip); position += zone_size) {
+    if ((b = read_map(rip, position)) != NO_BLOCK) {
+      z = (zone_nr)b >> scale;
+      free_zone(dev, z);
+    }
   }
 
   /* All the data zones have been freed.  Now free the indirect zones. */
-  free_zone(dev, rip->i_zone[NR_DZONE_NUM]);	/* single indirect zone */
-  if ( (z = rip->i_zone[NR_DZONE_NUM+1]) != NO_ZONE) {
-	b = (block_nr) z << scale;
-	bp = get_block(dev, b, NORMAL);	/* get double indirect zone */
-	for (iz = &bp->b_ind[0]; iz < &bp->b_ind[NR_INDIRECTS]; iz++) {
-		free_zone(dev, *iz);
-	}
+  free_zone(dev, rip->i_zone[NR_DZONE_NUM]); /* single indirect zone */
+  if ((z = rip->i_zone[NR_DZONE_NUM + 1]) != NO_ZONE) {
+    b = (block_nr)z << scale;
+    bp = get_block(dev, b, NORMAL); /* get double indirect zone */
+    for (iz = &bp->b_ind[0]; iz < &bp->b_ind[NR_INDIRECTS]; iz++) {
+      free_zone(dev, *iz);
+    }
 
-	/* Now free the double indirect zone itself. */
-	put_block(bp, INDIRECT_BLOCK);
-	free_zone(dev, z);
+    /* Now free the double indirect zone itself. */
+    put_block(bp, INDIRECT_BLOCK);
+    free_zone(dev, z);
   }
 
   /* The inode being truncated might currently be open, so certain fields must

--- a/fs/open.c
+++ b/fs/open.c
@@ -9,27 +9,27 @@
  *   do_lseek:  perform the LSEEK system call
  */
 
-#include "../h/const.h"
-#include "../h/type.h"
 #include "../h/callnr.h"
+#include "../h/const.h"
 #include "../h/error.h"
-#include "const.h"
-#include "type.h"
+#include "../h/type.h"
 #include "buf.h"
+#include "compat.h"
+#include "const.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "param.h"
+#include "type.h"
 
-PRIVATE char mode_map[] = {R_BIT, W_BIT, R_BIT|W_BIT, 0};
+PRIVATE char mode_map[] = {R_BIT, W_BIT, R_BIT | W_BIT, 0};
 
 /*===========================================================================*
  *				do_creat				     *
  *===========================================================================*/
-PUBLIC int do_creat()
-{
-/* Perform the creat(name, mode) system call. */
+PUBLIC int do_creat() {
+  /* Perform the creat(name, mode) system call. */
 
   register struct inode *rip;
   register int r;
@@ -39,84 +39,87 @@ PUBLIC int do_creat()
   extern struct inode *new_node();
 
   /* See if name ok and file descriptor and filp slots are available. */
-  if (fetch_name(name, name_length, M3) != OK) return(err_code);
-  if ( (r = get_fd(W_BIT, &file_d, &fil_ptr)) != OK) return(r);
+  if (fetch_name(name, name_length, M3) != OK)
+    return (err_code);
+  if ((r = get_fd(W_BIT, &file_d, &fil_ptr)) != OK)
+    return (r);
 
   /* Create a new inode by calling new_node(). */
   bits = I_REGULAR | (mode & ALL_MODES & fp->fp_umask);
   rip = new_node(user_path, bits, NO_ZONE);
   r = err_code;
-  if (r != OK && r != EEXIST) return(r);
+  if (r != OK && r != EEXIST)
+    return (r);
 
   /* At this point two possibilities exist: the given path did not exist
    * and has been created, or it pre-existed.  In the later case, truncate
    * if possible, otherwise return an error.
    */
   if (r == EEXIST) {
-	/* File exists already. */
-	switch (rip->i_mode & I_TYPE) {
-	    case I_REGULAR:		/* truncate regular file */
-		if ( (r = forbidden(rip, W_BIT, 0)) == OK) truncate(rip);
-		break;
+    /* File exists already. */
+    switch (rip->i_mode & I_TYPE) {
+    case I_REGULAR: /* truncate regular file */
+      if ((r = forbidden(rip, W_BIT, 0)) == OK)
+        truncate(rip);
+      break;
 
-	    case I_DIRECTORY:	/* can't truncate directory */
-		r = EISDIR;
-		break;
+    case I_DIRECTORY: /* can't truncate directory */
+      r = EISDIR;
+      break;
 
-	    case I_CHAR_SPECIAL:	/* special files are special */
-	    case I_BLOCK_SPECIAL:
-		if ( (r = forbidden(rip, W_BIT, 0)) != OK) break;
-		r = dev_open( (dev_nr) rip->i_zone[0], W_BIT);
-		break;
-	}
+    case I_CHAR_SPECIAL: /* special files are special */
+    case I_BLOCK_SPECIAL:
+      if ((r = forbidden(rip, W_BIT, 0)) != OK)
+        break;
+      r = dev_open((dev_nr)rip->i_zone[0], W_BIT);
+      break;
+    }
   }
 
   /* If error, return inode. */
   if (r != OK) {
-	put_inode(rip);
-	return(r);
+    put_inode(rip);
+    return (r);
   }
 
   /* Claim the file descriptor and filp slot and fill them in. */
   fp->fp_filp[file_d] = fil_ptr;
   fil_ptr->filp_count = 1;
   fil_ptr->filp_ino = rip;
-  return(file_d);
+  return (file_d);
 }
-
-
 
 /*===========================================================================*
  *				do_mknod				     *
  *===========================================================================*/
-PUBLIC int do_mknod()
-{
-/* Perform the mknod(name, mode, addr) system call. */
+PUBLIC int do_mknod() {
+  /* Perform the mknod(name, mode, addr) system call. */
 
   register mask_bits bits;
 
-  if (!super_user) return(EPERM);	/* only super_user may make nodes */
-  if (fetch_name(name1, name1_length, M1) != OK) return(err_code);
-  bits = (mode & I_TYPE) | (mode  & ALL_MODES & fp->fp_umask);
-  put_inode(new_node(user_path, bits, (zone_nr) addr));
-  return(err_code);
+  if (!super_user)
+    return (EPERM); /* only super_user may make nodes */
+  if (fetch_name(name1, name1_length, M1) != OK)
+    return (err_code);
+  bits = (mode & I_TYPE) | (mode & ALL_MODES & fp->fp_umask);
+  put_inode(new_node(user_path, bits, (zone_nr)addr));
+  return (err_code);
 }
-
 
 /*===========================================================================*
  *				new_node				     *
  *===========================================================================*/
 PRIVATE struct inode *new_node(path, bits, z0)
-char *path;			/* pointer to path name */
-mask_bits bits;			/* mode of the new inode */
-zone_nr z0;			/* zone number 0 for new inode */
+char *path;     /* pointer to path name */
+mask_bits bits; /* mode of the new inode */
+zone_nr z0;     /* zone number 0 for new inode */
 {
-/* This function is called by do_creat() and do_mknod().  In both cases it
- * allocates a new inode, makes a directory entry for it on the path 'path',
- * and initializes it.  It returns a pointer to the inode if it can do this;
- * err_code is set to OK or EEXIST. If it can't, it returns NIL_INODE and
- * 'err_code' contains the appropriate message.
- */
+  /* This function is called by do_creat() and do_mknod().  In both cases it
+   * allocates a new inode, makes a directory entry for it on the path 'path',
+   * and initializes it.  It returns a pointer to the inode if it can do this;
+   * err_code is set to OK or EEXIST. If it can't, it returns NIL_INODE and
+   * 'err_code' contains the appropriate message.
+   */
 
   register struct inode *rlast_dir_ptr, *rip;
   register int r;
@@ -124,57 +127,56 @@ zone_nr z0;			/* zone number 0 for new inode */
   extern struct inode *alloc_inode(), *advance(), *last_dir();
 
   /* See if the path can be opened down to the last directory. */
-  if ((rlast_dir_ptr = last_dir(path, string)) == NIL_INODE) return(NIL_INODE);
+  if ((rlast_dir_ptr = last_dir(path, string)) == NIL_INODE)
+    return (NIL_INODE);
 
   /* The final directory is accessible. Get final component of the path. */
   rip = advance(rlast_dir_ptr, string);
-  if ( rip == NIL_INODE && err_code == ENOENT) {
-	/* Last path component does not exist.  Make new directory entry. */
-	if ( (rip = alloc_inode(rlast_dir_ptr->i_dev, bits)) == NIL_INODE) {
-		/* Can't creat new inode: out of inodes. */
-		put_inode(rlast_dir_ptr);
-		return(NIL_INODE);
-	}
+  if (rip == NIL_INODE && err_code == ENOENT) {
+    /* Last path component does not exist.  Make new directory entry. */
+    if ((rip = alloc_inode(rlast_dir_ptr->i_dev, bits)) == NIL_INODE) {
+      /* Can't creat new inode: out of inodes. */
+      put_inode(rlast_dir_ptr);
+      return (NIL_INODE);
+    }
 
-	/* Force inode to the disk before making directory entry to make
-	 * the system more robust in the face of a crash: an inode with
-	 * no directory entry is much better than the opposite.
-	 */
-	rip->i_nlinks++;
-	rip->i_zone[0] = z0;
-	rw_inode(rip, WRITING);		/* force inode to disk now */
+    /* Force inode to the disk before making directory entry to make
+     * the system more robust in the face of a crash: an inode with
+     * no directory entry is much better than the opposite.
+     */
+    rip->i_nlinks++;
+    rip->i_zone[0] = z0;
+    rw_inode(rip, WRITING); /* force inode to disk now */
 
-	/* New inode acquired.  Try to make directory entry. */
-	if ((r = search_dir(rlast_dir_ptr, string, &rip->i_num,ENTER)) != OK) {
-		put_inode(rlast_dir_ptr);
-		rip->i_nlinks--;	/* pity, have to free disk inode */
-		rip->i_dirt = DIRTY;	/* dirty inodes are written out */
-		put_inode(rip);	/* this call frees the inode */
-		err_code = r;
-		return(NIL_INODE);
-	}
+    /* New inode acquired.  Try to make directory entry. */
+    if ((r = search_dir(rlast_dir_ptr, string, &rip->i_num, ENTER)) != OK) {
+      put_inode(rlast_dir_ptr);
+      rip->i_nlinks--;     /* pity, have to free disk inode */
+      rip->i_dirt = DIRTY; /* dirty inodes are written out */
+      put_inode(rip);      /* this call frees the inode */
+      err_code = r;
+      return (NIL_INODE);
+    }
 
   } else {
-	/* Either last component exists, or there is some problem. */
-	if (rip != NIL_INODE)
-		r = EEXIST;
-	else
-		r = err_code;
+    /* Either last component exists, or there is some problem. */
+    if (rip != NIL_INODE)
+      r = EEXIST;
+    else
+      r = err_code;
   }
 
   /* Return the directory inode and exit. */
   put_inode(rlast_dir_ptr);
   err_code = r;
-  return(rip);
+  return (rip);
 }
-
 
 /*===========================================================================*
  *				do_open					     *
  *===========================================================================*/
-PUBLIC int do_open()
-{
-/* Perform the open(name, mode) system call. */
+PUBLIC int do_open() {
+  /* Perform the open(name, mode) system call. */
 
   register struct inode *rip;
   struct filp *fil_ptr;
@@ -187,53 +189,56 @@ PUBLIC int do_open()
    * 'mode' is 0 for read, 1 for write, 2 for read+write.  The variable
    * 'bits' needs to be R_BIT, W_BIT, and R_BIT|W_BIT respectively.
    */
-  if (mode < 0 || mode > 2) return(EINVAL);
-  if (fetch_name(name, name_length, M3) != OK) return(err_code);
-  bits = (mask_bits) mode_map[mode];
-  if ( (r = get_fd(bits, &file_d, &fil_ptr)) != OK) return(r);
+  if (mode < 0 || mode > 2)
+    return (EINVAL);
+  if (fetch_name(name, name_length, M3) != OK)
+    return (err_code);
+  bits = (mask_bits)mode_map[mode];
+  if ((r = get_fd(bits, &file_d, &fil_ptr)) != OK)
+    return (r);
 
   /* Scan path name. */
-  if ( (rip = eat_path(user_path)) == NIL_INODE) return(err_code);
+  if ((rip = eat_path(user_path)) == NIL_INODE)
+    return (err_code);
 
   if ((r = forbidden(rip, bits, 0)) != OK) {
-	put_inode(rip);          /* can't open: protection violation */
-	return(r);
+    put_inode(rip); /* can't open: protection violation */
+    return (r);
   }
 
   /* Opening regular files, directories and special files are different. */
   switch (rip->i_mode & I_TYPE) {
-     case I_DIRECTORY:
-	if (bits & W_BIT) {
-		put_inode(rip);
-		return(EISDIR);
-	}
-	break;
+  case I_DIRECTORY:
+    if (bits & W_BIT) {
+      put_inode(rip);
+      return (EISDIR);
+    }
+    break;
 
-     case I_CHAR_SPECIAL:
-	/* Assume that first open of char special file is controlling tty. */
-	if (fp->fs_tty == 0) fp->fs_tty = (dev_nr) rip->i_zone[0];
-	dev_open((dev_nr) rip->i_zone[0], (int) bits);
-	break;
+  case I_CHAR_SPECIAL:
+    /* Assume that first open of char special file is controlling tty. */
+    if (fp->fs_tty == 0)
+      fp->fs_tty = (dev_nr)rip->i_zone[0];
+    dev_open((dev_nr)rip->i_zone[0], (int)bits);
+    break;
 
-     case I_BLOCK_SPECIAL:
-	dev_open((dev_nr) rip->i_zone[0], (int) bits);
-	break;
+  case I_BLOCK_SPECIAL:
+    dev_open((dev_nr)rip->i_zone[0], (int)bits);
+    break;
   }
 
   /* Claim the file descriptor and filp slot and fill them in. */
   fp->fp_filp[file_d] = fil_ptr;
   fil_ptr->filp_count = 1;
   fil_ptr->filp_ino = rip;
-  return(file_d);
+  return (file_d);
 }
-
 
 /*===========================================================================*
  *				do_close				     *
  *===========================================================================*/
-PUBLIC int do_close()
-{
-/* Perform the close(fd) system call. */
+PUBLIC int do_close() {
+  /* Perform the close(fd) system call. */
 
   register struct filp *rfilp;
   register struct inode *rip;
@@ -242,63 +247,74 @@ PUBLIC int do_close()
   extern struct filp *get_filp();
 
   /* First locate the inode that belongs to the file descriptor. */
-  if ( (rfilp = get_filp(fd)) == NIL_FILP) return(err_code);
-  rip = rfilp->filp_ino;	/* 'rip' points to the inode */
+  if ((rfilp = get_filp(fd)) == NIL_FILP)
+    return (err_code);
+  rip = rfilp->filp_ino; /* 'rip' points to the inode */
 
   /* Check to see if the file is special. */
   mode_word = rip->i_mode & I_TYPE;
   if (mode_word == I_CHAR_SPECIAL || mode_word == I_BLOCK_SPECIAL) {
-	if (mode_word == I_BLOCK_SPECIAL)  {
-		/* Invalidate cache entries unless special is mounted or ROOT.*/
-		do_sync();	/* purge cache */
-		if (mounted(rip) == FALSE) invalidate((dev_nr) rip->i_zone[0]);
-	}
-	dev_close((dev_nr) rip->i_zone[0]);
+    if (mode_word == I_BLOCK_SPECIAL) {
+      /* Invalidate cache entries unless special is mounted or ROOT.*/
+      do_sync(); /* purge cache */
+      if (mounted(rip) == FALSE)
+        invalidate((dev_nr)rip->i_zone[0]);
+    }
+    dev_close((dev_nr)rip->i_zone[0]);
   }
 
   /* If the inode being closed is a pipe, release everyone hanging on it. */
   if (rfilp->filp_ino->i_pipe) {
-	rw = (rfilp->filp_mode & R_BIT ? WRITE : READ);
-	release(rfilp->filp_ino, rw, NR_PROCS);
+    rw = (rfilp->filp_mode & R_BIT ? WRITE : READ);
+    release(rfilp->filp_ino, rw, NR_PROCS);
   }
 
   /* If a write has been done, the inode is already marked as DIRTY. */
-  if (--rfilp->filp_count == 0) put_inode(rfilp->filp_ino);
+  if (--rfilp->filp_count == 0)
+    put_inode(rfilp->filp_ino);
 
   fp->fp_filp[fd] = NIL_FILP;
-  return(OK);
+  return (OK);
 }
-
 
 /*===========================================================================*
  *				do_lseek				     *
  *===========================================================================*/
-PUBLIC int do_lseek()
-{
-/* Perform the lseek(ls_fd, offset, whence) system call. */
+PUBLIC int do_lseek() {
+  /* Perform the lseek(ls_fd, offset, whence) system call. */
 
   register struct filp *rfilp;
-  register file_pos pos;
+  register file_pos64 pos;
   extern struct filp *get_filp();
 
   /* Check to see if the file descriptor is valid. */
-  if ( (rfilp = get_filp(ls_fd)) == NIL_FILP) return(err_code);
+  if ((rfilp = get_filp(ls_fd)) == NIL_FILP)
+    return (err_code);
 
   /* No lseek on pipes. */
-  if (rfilp->filp_ino->i_pipe == I_PIPE) return(ESPIPE);
+  if (rfilp->filp_ino->i_pipe == I_PIPE)
+    return (ESPIPE);
 
   /* The value of 'whence' determines the algorithm to use. */
-  switch(whence) {
-	case 0:	pos = offset;	break;
-	case 1: pos = rfilp->filp_pos + offset;	break;
-	case 2: pos = rfilp->filp_ino->i_size + offset;	break;
-	default: return(EINVAL);
+  switch (whence) {
+  case 0:
+    pos = offset;
+    break;
+  case 1:
+    pos = rfilp->filp_pos + offset;
+    break;
+  case 2:
+    pos = compat_get_size(rfilp->filp_ino) + offset;
+    break;
+  default:
+    return (EINVAL);
   }
-  if (pos < (file_pos) 0) return(EINVAL);
+  if (pos < (file_pos64)0)
+    return (EINVAL);
 
-  rfilp->filp_ino->i_seek = ISEEK;	/* inhibit read ahead */
+  rfilp->filp_ino->i_seek = ISEEK; /* inhibit read ahead */
   rfilp->filp_pos = pos;
 
-  reply_l1 = pos;		/* insert the long into the output message */
-  return(OK);
+  reply_l1 = (long)pos; /* insert the long into the output message */
+  return (OK);
 }

--- a/fs/path.c
+++ b/fs/path.c
@@ -9,59 +9,61 @@
  */
 
 #include "../h/const.h"
-#include "../h/type.h"
 #include "../h/error.h"
-#include "const.h"
-#include "type.h"
+#include "../h/type.h"
 #include "buf.h"
+#include "compat.h"
+#include "const.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "super.h"
+#include "type.h"
 
 /*===========================================================================*
  *				eat_path				     *
  *===========================================================================*/
 PUBLIC struct inode *eat_path(path)
-char *path;			/* the path name to be parsed */
+char *path; /* the path name to be parsed */
 {
-/* Parse the path 'path' and put its inode in the inode table.  If not
- * possible, return NIL_INODE as function value and an error code in 'err_code'.
- */
+  /* Parse the path 'path' and put its inode in the inode table.  If not
+   * possible, return NIL_INODE as function value and an error code in
+   * 'err_code'.
+   */
 
   register struct inode *ldip, *rip;
-  char string[NAME_SIZE];	/* hold 1 path component name here */
+  char string[NAME_SIZE]; /* hold 1 path component name here */
   extern struct inode *last_dir(), *advance();
 
   /* First open the path down to the final directory. */
-  if ( (ldip = last_dir(path, string)) == NIL_INODE)
-	return(NIL_INODE);	/* we couldn't open final directory */
+  if ((ldip = last_dir(path, string)) == NIL_INODE)
+    return (NIL_INODE); /* we couldn't open final directory */
 
   /* The path consisting only of "/" is a special case, check for it. */
-  if (string[0] == '\0') return(ldip);
+  if (string[0] == '\0')
+    return (ldip);
 
   /* Get final component of the path. */
   rip = advance(ldip, string);
   put_inode(ldip);
-  return(rip);
+  return (rip);
 }
-
 
 /*===========================================================================*
  *				last_dir				     *
  *===========================================================================*/
 PUBLIC struct inode *last_dir(path, string)
-char *path;			/* the path name to be parsed */
-char string[NAME_SIZE];		/* the final component is returned here */
+char *path;             /* the path name to be parsed */
+char string[NAME_SIZE]; /* the final component is returned here */
 {
-/* Given a path, 'path', located in the fs address space, parse it as
- * far as the last directory, fetch the inode for the last directory into
- * the inode table, and return a pointer to the inode.  In
- * addition, return the final component of the path in 'string'.
- * If the last directory can't be opened, return NIL_INODE and
- * the reason for failure in 'err_code'.
- */
+  /* Given a path, 'path', located in the fs address space, parse it as
+   * far as the last directory, fetch the inode for the last directory into
+   * the inode table, and return a pointer to the inode.  In
+   * addition, return the final component of the path in 'string'.
+   * If the last directory can't be opened, return NIL_INODE and
+   * the reason for failure in 'err_code'.
+   */
 
   register struct inode *rip;
   register char *new_name;
@@ -71,83 +73,87 @@ char string[NAME_SIZE];		/* the final component is returned here */
 
   /* Is the path absolute or relative?  Initialize 'rip' accordingly. */
   rip = (*path == '/' ? fp->fp_rootdir : fp->fp_workdir);
-  dup_inode(rip);		/* inode will be returned with put_inode */
+  dup_inode(rip); /* inode will be returned with put_inode */
 
   /* Scan the path component by component. */
   while (TRUE) {
-	/* Extract one component. */
-	if ( (new_name = get_name(path, string)) == (char*) 0) {
-		put_inode(rip);	/* bad path in user space */
-		return(NIL_INODE);
-	}
-	if (*new_name == '\0') return(rip);	/* normal exit */
+    /* Extract one component. */
+    if ((new_name = get_name(path, string)) == (char *)0) {
+      put_inode(rip); /* bad path in user space */
+      return (NIL_INODE);
+    }
+    if (*new_name == '\0')
+      return (rip); /* normal exit */
 
-	/* There is more path.  Keep parsing. */
-	new_ip = advance(rip, string);
-	put_inode(rip);		/* rip either obsolete or irrelevant */
-	if (new_ip == NIL_INODE) return(NIL_INODE);
+    /* There is more path.  Keep parsing. */
+    new_ip = advance(rip, string);
+    put_inode(rip); /* rip either obsolete or irrelevant */
+    if (new_ip == NIL_INODE)
+      return (NIL_INODE);
 
-	/* The call to advance() succeeded.  Fetch next component. */
-	path = new_name;
-	rip = new_ip;
+    /* The call to advance() succeeded.  Fetch next component. */
+    path = new_name;
+    rip = new_ip;
   }
 }
-
 
 /*===========================================================================*
  *				get_name				     *
  *===========================================================================*/
 PRIVATE char *get_name(old_name, string)
-char *old_name;			/* path name to parse */
-char string[NAME_SIZE];		/* component extracted from 'old_name' */
+char *old_name;         /* path name to parse */
+char string[NAME_SIZE]; /* component extracted from 'old_name' */
 {
-/* Given a pointer to a path name in fs space, 'old_name', copy the next
- * component to 'string' and pad with zeros.  A pointer to that part of
- * the name as yet unparsed is returned.  Roughly speaking,
- * 'get_name' = 'old_name' - 'string'.
- *
- * This routine follows the standard convention that /usr/ast, /usr//ast,
- * //usr///ast and /usr/ast/ are all equivalent.
- */
+  /* Given a pointer to a path name in fs space, 'old_name', copy the next
+   * component to 'string' and pad with zeros.  A pointer to that part of
+   * the name as yet unparsed is returned.  Roughly speaking,
+   * 'get_name' = 'old_name' - 'string'.
+   *
+   * This routine follows the standard convention that /usr/ast, /usr//ast,
+   * //usr///ast and /usr/ast/ are all equivalent.
+   */
 
   register int c;
   register char *np, *rnp;
 
-  np = string;			/* 'np' points to current position */
-  rnp = old_name;		/* 'rnp' points to unparsed string */
-  while ( (c = *rnp) == '/') rnp++;	/* skip leading slashes */
+  np = string;    /* 'np' points to current position */
+  rnp = old_name; /* 'rnp' points to unparsed string */
+  while ((c = *rnp) == '/')
+    rnp++; /* skip leading slashes */
 
   /* Copy the unparsed path, 'old_name', to the array, 'string'. */
-  while ( rnp < &user_path[MAX_PATH]  &&  c != '/'   &&  c != '\0') {
-	if (np < &string[NAME_SIZE]) *np++ = c;
-	c = *++rnp;		/* advance to next character */
+  while (rnp < &user_path[MAX_PATH] && c != '/' && c != '\0') {
+    if (np < &string[NAME_SIZE])
+      *np++ = c;
+    c = *++rnp; /* advance to next character */
   }
 
   /* To make /usr/ast/ equivalent to /usr/ast, skip trailing slashes. */
-  while (c == '/' && rnp < &user_path[MAX_PATH]) c = *++rnp;
+  while (c == '/' && rnp < &user_path[MAX_PATH])
+    c = *++rnp;
 
   /* Pad the component name out to NAME_SIZE chars, using 0 as filler. */
-  while (np < &string[NAME_SIZE]) *np++ = '\0';
+  while (np < &string[NAME_SIZE])
+    *np++ = '\0';
 
   if (rnp >= &user_path[MAX_PATH]) {
-	err_code = E_LONG_STRING;
-	return((char *) 0);
+    err_code = E_LONG_STRING;
+    return ((char *)0);
   }
-  return(rnp);
+  return (rnp);
 }
-
 
 /*===========================================================================*
  *				advance					     *
  *===========================================================================*/
 PUBLIC struct inode *advance(dirp, string)
-struct inode *dirp;		/* inode for directory to be searched */
-char string[NAME_SIZE];		/* component name to look for */
+struct inode *dirp;     /* inode for directory to be searched */
+char string[NAME_SIZE]; /* component name to look for */
 {
-/* Given a directory and a component of a path, look up the component in
- * the directory, find the inode, open it, and return a pointer to its inode
- * slot.  If it can't be done, return NIL_INODE.
- */
+  /* Given a directory and a component of a path, look up the component in
+   * the directory, find the inode, open it, and return a pointer to its inode
+   * slot.  If it can't be done, return NIL_INODE.
+   */
 
   register struct inode *rip;
   struct inode *rip2;
@@ -158,70 +164,71 @@ char string[NAME_SIZE];		/* component name to look for */
   extern struct inode *get_inode();
 
   /* If 'string' is empty, yield same inode straight away. */
-  if (string[0] == '\0') return(get_inode(dirp->i_dev, dirp->i_num));
+  if (string[0] == '\0')
+    return (get_inode(dirp->i_dev, dirp->i_num));
 
   /* If 'string' is not present in the directory, signal error. */
-  if ( (r = search_dir(dirp, string, &numb, LOOK_UP)) != OK) {
-	err_code = r;
-	return(NIL_INODE);
+  if ((r = search_dir(dirp, string, &numb, LOOK_UP)) != OK) {
+    err_code = r;
+    return (NIL_INODE);
   }
 
   /* The component has been found in the directory.  Get inode. */
-  if ( (rip = get_inode(dirp->i_dev, numb)) == NIL_INODE) return(NIL_INODE);
+  if ((rip = get_inode(dirp->i_dev, numb)) == NIL_INODE)
+    return (NIL_INODE);
 
   if (rip->i_num == ROOT_INODE)
-	if (dirp->i_num == ROOT_INODE) {
-	    if (string[1] == '.') {
-		for (sp = &super_block[1]; sp < &super_block[NR_SUPERS]; sp++) {
-			if (sp->s_dev == rip->i_dev) {
-				/* Release the root inode.  Replace by the
-				 * inode mounted on.
-				 */
-				put_inode(rip);
-				mnt_dev = sp->s_imount->i_dev;
-				rip2 = get_inode(mnt_dev, sp->s_imount->i_num);
-				rip = advance(rip2, string);
-				put_inode(rip2);
-				break;
-			}
-		}
-	    }
-	}
+    if (dirp->i_num == ROOT_INODE) {
+      if (string[1] == '.') {
+        for (sp = &super_block[1]; sp < &super_block[NR_SUPERS]; sp++) {
+          if (sp->s_dev == rip->i_dev) {
+            /* Release the root inode.  Replace by the
+             * inode mounted on.
+             */
+            put_inode(rip);
+            mnt_dev = sp->s_imount->i_dev;
+            rip2 = get_inode(mnt_dev, sp->s_imount->i_num);
+            rip = advance(rip2, string);
+            put_inode(rip2);
+            break;
+          }
+        }
+      }
+    }
   /* See if the inode is mounted on.  If so, switch to root directory of the
    * mounted file system.  The super_block provides the linkage between the
    * inode mounted on and the root directory of the mounted file system.
    */
   while (rip->i_mount == I_MOUNT) {
-	/* The inode is indeed mounted on. */
-	for (sp = &super_block[0]; sp < &super_block[NR_SUPERS]; sp++) {
-		if (sp->s_imount == rip) {
-			/* Release the inode mounted on.  Replace by the
-			 * inode of the root inode of the mounted device.
-			 */
-			put_inode(rip);
-			rip = get_inode(sp->s_dev, ROOT_INODE);
-			break;
-		}
-	}
+    /* The inode is indeed mounted on. */
+    for (sp = &super_block[0]; sp < &super_block[NR_SUPERS]; sp++) {
+      if (sp->s_imount == rip) {
+        /* Release the inode mounted on.  Replace by the
+         * inode of the root inode of the mounted device.
+         */
+        put_inode(rip);
+        rip = get_inode(sp->s_dev, ROOT_INODE);
+        break;
+      }
+    }
   }
-  return(rip);		/* return pointer to inode's component */
+  return (rip); /* return pointer to inode's component */
 }
-
 
 /*===========================================================================*
  *				search_dir				     *
  *===========================================================================*/
 PUBLIC int search_dir(ldir_ptr, string, numb, flag)
-register struct inode *ldir_ptr;	/* ptr to inode for dir to search */
-char string[NAME_SIZE];		/* component to search for */
-inode_nr *numb;			/* pointer to inode number */
-int flag;			/* LOOK_UP, ENTER, or DELETE */
+register struct inode *ldir_ptr; /* ptr to inode for dir to search */
+char string[NAME_SIZE];          /* component to search for */
+inode_nr *numb;                  /* pointer to inode number */
+int flag;                        /* LOOK_UP, ENTER, or DELETE */
 {
-/* This function searches the directory whose inode is pointed to by 'ldip':
- * if (flag == LOOK_UP) search for 'string' and return inode # in 'numb';
- * if (flag == ENTER)  enter 'string' in the directory with inode # '*numb';
- * if (flag == DELETE) delete 'string' from the directory;
- */
+  /* This function searches the directory whose inode is pointed to by 'ldip':
+   * if (flag == LOOK_UP) search for 'string' and return inode # in 'numb';
+   * if (flag == ENTER)  enter 'string' in the directory with inode # '*numb';
+   * if (flag == DELETE) delete 'string' from the directory;
+   */
 
   register dir_struct *dp;
   register struct buf *bp;
@@ -236,64 +243,69 @@ int flag;			/* LOOK_UP, ENTER, or DELETE */
   extern real_time clock_time();
 
   /* If 'ldir_ptr' is not a pointer to a searchable dir inode, error. */
-  if ( (ldir_ptr->i_mode & I_TYPE) != I_DIRECTORY) return(ENOTDIR);
-  bits = (flag == LOOK_UP ? X_BIT : W_BIT|X_BIT);
-  if ( (r = forbidden(ldir_ptr, bits, 0)) != OK)
-	return(r);
+  if ((ldir_ptr->i_mode & I_TYPE) != I_DIRECTORY)
+    return (ENOTDIR);
+  bits = (flag == LOOK_UP ? X_BIT : W_BIT | X_BIT);
+  if ((r = forbidden(ldir_ptr, bits, 0)) != OK)
+    return (r);
 
   /* Step through the directory one block at a time. */
-  old_slots = ldir_ptr->i_size/DIR_ENTRY_SIZE;
+  old_slots = compat_get_size(ldir_ptr) / DIR_ENTRY_SIZE;
   new_slots = 0;
   e_hit = FALSE;
-  for (pos = 0; pos < ldir_ptr->i_size; pos += BLOCK_SIZE) {
-	b = read_map(ldir_ptr, pos);	/* get block number */
+  for (pos = 0; pos < compat_get_size(ldir_ptr); pos += BLOCK_SIZE) {
+    b = read_map(ldir_ptr, pos); /* get block number */
 
-	/* Since directories don't have holes, 'b' cannot be NO_BLOCK. */
-	bp = get_block(ldir_ptr->i_dev, b, NORMAL);	/* get a dir block */
+    /* Since directories don't have holes, 'b' cannot be NO_BLOCK. */
+    bp = get_block(ldir_ptr->i_dev, b, NORMAL); /* get a dir block */
 
-	/* Search a directory block. */
-	for (dp = &bp->b_dir[0]; dp < &bp->b_dir[NR_DIR_ENTRIES]; dp++) {
-		if (++new_slots > old_slots) { /* not found, but room left */
-			if (flag == ENTER) e_hit = TRUE;
-			break;
-		}
-		if (flag != ENTER && dp->d_inum != 0
-				&& cmp_string(dp->d_name, string, NAME_SIZE)) {
-			/* LOOK_UP or DELETE found what it wanted. */
-			if (flag == DELETE) {
-				dp->d_inum = 0;	/* erase entry */
-				bp->b_dirt = DIRTY;
-				ldir_ptr->i_modtime = clock_time();
-			} else
-				*numb = dp->d_inum;	/* 'flag' is LOOK_UP */
-			put_block(bp, DIRECTORY_BLOCK);
-			return(OK);
-		}
+    /* Search a directory block. */
+    for (dp = &bp->b_dir[0]; dp < &bp->b_dir[NR_DIR_ENTRIES]; dp++) {
+      if (++new_slots > old_slots) { /* not found, but room left */
+        if (flag == ENTER)
+          e_hit = TRUE;
+        break;
+      }
+      if (flag != ENTER && dp->d_inum != 0 &&
+          cmp_string(dp->d_name, string, NAME_SIZE)) {
+        /* LOOK_UP or DELETE found what it wanted. */
+        if (flag == DELETE) {
+          dp->d_inum = 0; /* erase entry */
+          bp->b_dirt = DIRTY;
+          ldir_ptr->i_modtime = clock_time();
+        } else
+          *numb = dp->d_inum; /* 'flag' is LOOK_UP */
+        put_block(bp, DIRECTORY_BLOCK);
+        return (OK);
+      }
 
-		/* Check for free slot for the benefit of ENTER. */
-		if (flag == ENTER && dp->d_inum == 0) {
-			e_hit = TRUE;	/* we found a free slot */
-			break;
-		}
-	}
+      /* Check for free slot for the benefit of ENTER. */
+      if (flag == ENTER && dp->d_inum == 0) {
+        e_hit = TRUE; /* we found a free slot */
+        break;
+      }
+    }
 
-	/* The whole block has been searched or ENTER has a free slot. */
-	if (e_hit) break;	/* e_hit set if ENTER can be performed now */
-	put_block(bp, DIRECTORY_BLOCK);	/* otherwise, continue searching dir */
+    /* The whole block has been searched or ENTER has a free slot. */
+    if (e_hit)
+      break; /* e_hit set if ENTER can be performed now */
+    put_block(bp, DIRECTORY_BLOCK); /* otherwise, continue searching dir */
   }
 
   /* The whole directory has now been searched. */
-  if (flag != ENTER) return(ENOENT);
+  if (flag != ENTER)
+    return (ENOENT);
 
   /* This call is for ENTER.  If no free slot has been found so far, try to
    * extend directory.
    */
   if (e_hit == FALSE) { /* directory is full and no room left in last block */
-	new_slots ++;		/* increase directory size by 1 entry */
-	if (new_slots == 0) return(EFBIG); /* dir size limited by slot count */
-	if ( (bp = new_block(ldir_ptr, ldir_ptr->i_size)) == NIL_BUF)
-		return(err_code);
-	dp = &bp->b_dir[0];
+    new_slots++;        /* increase directory size by 1 entry */
+    if (new_slots == 0)
+      return (EFBIG); /* dir size limited by slot count */
+    if ((bp = new_block(ldir_ptr, compat_get_size(ldir_ptr))) == NIL_BUF)
+      return (err_code);
+    dp = &bp->b_dir[0];
   }
 
   /* 'bp' now points to a directory block with space. 'dp' points to slot. */
@@ -302,9 +314,7 @@ int flag;			/* LOOK_UP, ENTER, or DELETE */
   bp->b_dirt = DIRTY;
   put_block(bp, DIRECTORY_BLOCK);
   ldir_ptr->i_modtime = clock_time();
-  ldir_ptr->i_dirt = DIRTY;
   if (new_slots > old_slots)
-	ldir_ptr->i_size = (file_pos) new_slots * DIR_ENTRY_SIZE;
-  return(OK);
+    compat_set_size(ldir_ptr, (file_pos)new_slots * DIR_ENTRY_SIZE);
+  return (OK);
 }
-

--- a/fs/pipe.c
+++ b/fs/pipe.c
@@ -13,192 +13,197 @@
  *   do_unpause:  a signal has been sent to a process; see if it suspended
  */
 
-#include "../h/const.h"
-#include "../h/type.h"
 #include "../h/callnr.h"
 #include "../h/com.h"
+#include "../h/const.h"
 #include "../h/error.h"
 #include "../h/signal.h"
+#include "../h/type.h"
+#include "compat.h"
 #include "const.h"
-#include "type.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "param.h"
+#include "type.h"
 
 PRIVATE message mess;
 
 /*===========================================================================*
  *				do_pipe					     *
  *===========================================================================*/
-PUBLIC int do_pipe()
-{
-/* Perform the pipe(fil_des) system call. */
+PUBLIC int do_pipe() {
+  /* Perform the pipe(fil_des) system call. */
 
   register struct fproc *rfp;
   register struct inode *rip;
   int r;
   dev_nr device;
   struct filp *fil_ptr0, *fil_ptr1;
-  int fil_des[2];		/* reply goes here */
+  int fil_des[2]; /* reply goes here */
   extern struct inode *alloc_inode();
 
   /* Acquire two file descriptors. */
   rfp = fp;
-  if ( (r = get_fd(R_BIT, &fil_des[0], &fil_ptr0)) != OK) return(r);
+  if ((r = get_fd(R_BIT, &fil_des[0], &fil_ptr0)) != OK)
+    return (r);
   rfp->fp_filp[fil_des[0]] = fil_ptr0;
   fil_ptr0->filp_count = 1;
-  if ( (r = get_fd(W_BIT, &fil_des[1], &fil_ptr1)) != OK) {
-	rfp->fp_filp[fil_des[0]] = NIL_FILP;
-	fil_ptr0->filp_count = 0;
-	return(r);
+  if ((r = get_fd(W_BIT, &fil_des[1], &fil_ptr1)) != OK) {
+    rfp->fp_filp[fil_des[0]] = NIL_FILP;
+    fil_ptr0->filp_count = 0;
+    return (r);
   }
   rfp->fp_filp[fil_des[1]] = fil_ptr1;
   fil_ptr1->filp_count = 1;
 
   /* Make the inode in the current working directory. */
-  device = rfp->fp_workdir->i_dev;	/* inode dev is same as working dir */
-  if ( (rip = alloc_inode(device, I_REGULAR)) == NIL_INODE) {
-	rfp->fp_filp[fil_des[0]] = NIL_FILP;
-	fil_ptr0->filp_count = 0;
-	rfp->fp_filp[fil_des[1]] = NIL_FILP;
-	fil_ptr1->filp_count = 0;
-	return(err_code);
+  device = rfp->fp_workdir->i_dev; /* inode dev is same as working dir */
+  if ((rip = alloc_inode(device, I_REGULAR)) == NIL_INODE) {
+    rfp->fp_filp[fil_des[0]] = NIL_FILP;
+    fil_ptr0->filp_count = 0;
+    rfp->fp_filp[fil_des[1]] = NIL_FILP;
+    fil_ptr1->filp_count = 0;
+    return (err_code);
   }
 
   rip->i_pipe = I_PIPE;
   fil_ptr0->filp_ino = rip;
-  dup_inode(rip);		/* for double usage */
+  dup_inode(rip); /* for double usage */
   fil_ptr1->filp_ino = rip;
-  rw_inode(rip, WRITING);	/* mark inode as allocated */
+  rw_inode(rip, WRITING); /* mark inode as allocated */
   reply_i1 = fil_des[0];
   reply_i2 = fil_des[1];
-  return(OK);
+  return (OK);
 }
-
 
 /*===========================================================================*
  *				pipe_check				     *
  *===========================================================================*/
 PUBLIC int pipe_check(rip, rw_flag, virgin, bytes, position)
-register struct inode *rip;	/* the inode of the pipe */
-int rw_flag;			/* READING or WRITING */
-int virgin;			/* 1 if no data transferred yet, else 0 */
-register int bytes;		/* bytes to be read or written (all chunks) */
-register file_pos *position;	/* pointer to current file position */
+register struct inode *rip;  /* the inode of the pipe */
+int rw_flag;                 /* READING or WRITING */
+int virgin;                  /* 1 if no data transferred yet, else 0 */
+register int bytes;          /* bytes to be read or written (all chunks) */
+register file_pos *position; /* pointer to current file position */
 {
-/* Pipes are a little different.  If a process reads from an empty pipe for
- * which a writer still exists, suspend the reader.  If the pipe is empty
- * and there is no writer, return 0 bytes.  If a process is writing to a
- * pipe and no one is reading from it, give a broken pipe error.
- */
+  /* Pipes are a little different.  If a process reads from an empty pipe for
+   * which a writer still exists, suspend the reader.  If the pipe is empty
+   * and there is no writer, return 0 bytes.  If a process is writing to a
+   * pipe and no one is reading from it, give a broken pipe error.
+   */
 
   extern struct filp *find_filp();
 
   /* If reading, check for empty pipe. */
   if (rw_flag == READING) {
-	if (*position >= rip->i_size) {
-		/* Process is reading from an empty pipe. */
-		if (find_filp(rip, W_BIT) != NIL_FILP) {
-			/* Writer exists; suspend rdr if no data already read.*/
-			if (virgin) suspend(XPIPE);	/* block reader */
+    if (*position >= compat_get_size(rip)) {
+      /* Process is reading from an empty pipe. */
+      if (find_filp(rip, W_BIT) != NIL_FILP) {
+        /* Writer exists; suspend rdr if no data already read.*/
+        if (virgin)
+          suspend(XPIPE); /* block reader */
 
-			/* If need be, activate sleeping writer. */
-			if (susp_count > 0) release(rip, WRITE, 1);
-		}
-		return(0);
-	}
+        /* If need be, activate sleeping writer. */
+        if (susp_count > 0)
+          release(rip, WRITE, 1);
+      }
+      return (0);
+    }
   } else {
-	/* Process is writing to a pipe. */
-	if (bytes > PIPE_SIZE) return(EFBIG);
-	if (find_filp(rip, R_BIT) == NIL_FILP) {
-		/* Tell MM to generate a SIGPIPE signal. */
-		mess.m_type = KSIG;
-		mess.PROC1 = fp - fproc;
-		mess.SIG_MAP = 1 << (SIGPIPE - 1);
-		send(MM_PROC_NR, &mess);
-		return(EPIPE);
-	}
+    /* Process is writing to a pipe. */
+    if (bytes > PIPE_SIZE)
+      return (EFBIG);
+    if (find_filp(rip, R_BIT) == NIL_FILP) {
+      /* Tell MM to generate a SIGPIPE signal. */
+      mess.m_type = KSIG;
+      mess.PROC1 = fp - fproc;
+      mess.SIG_MAP = 1 << (SIGPIPE - 1);
+      send(MM_PROC_NR, &mess);
+      return (EPIPE);
+    }
 
-	if (*position + bytes > PIPE_SIZE) {
-		suspend(XPIPE);	/* stop writer -- pipe full */
-		return(0);
-	}
+    if (*position + bytes > PIPE_SIZE) {
+      suspend(XPIPE); /* stop writer -- pipe full */
+      return (0);
+    }
 
-	/* Writing to an empty pipe.  Search for suspended reader. */
-	if (*position == 0) release(rip, READ, 1);
+    /* Writing to an empty pipe.  Search for suspended reader. */
+    if (*position == 0)
+      release(rip, READ, 1);
   }
 
-  return(1);
+  return (1);
 }
-
 
 /*===========================================================================*
  *				suspend					     *
  *===========================================================================*/
 PUBLIC suspend(task)
-int task;			/* who is proc waiting for? (PIPE = pipe) */
+int task; /* who is proc waiting for? (PIPE = pipe) */
 {
-/* Take measures to suspend the processing of the present system call.
- * Store the parameters to be used upon resuming in the process table.
- * (Actually they are not used when a process is waiting for an I/O device,
- * but they are needed for pipes, and it is not worth making the distinction.)
- */
+  /* Take measures to suspend the processing of the present system call.
+   * Store the parameters to be used upon resuming in the process table.
+   * (Actually they are not used when a process is waiting for an I/O device,
+   * but they are needed for pipes, and it is not worth making the distinction.)
+   */
 
-  if (task == XPIPE) susp_count++;	/* count procs suspended on pipe */
+  if (task == XPIPE)
+    susp_count++; /* count procs suspended on pipe */
   fp->fp_suspended = SUSPENDED;
   fp->fp_fd = fd << 8 | fs_call;
   fp->fp_buffer = buffer;
   fp->fp_nbytes = nbytes;
   fp->fp_task = -task;
-  dont_reply = TRUE;		/* do not send caller a reply message now */
+  dont_reply = TRUE; /* do not send caller a reply message now */
 }
-
 
 /*===========================================================================*
  *				release					     *
  *===========================================================================*/
 PUBLIC release(ip, call_nr, count)
-register struct inode *ip;	/* inode of pipe */
-int call_nr;			/* READ or WRITE */
-int count;			/* max number of processes to release */
+register struct inode *ip; /* inode of pipe */
+int call_nr;               /* READ or WRITE */
+int count;                 /* max number of processes to release */
 {
-/* Check to see if any process is hanging on the pipe whose inode is in 'ip'.
- * If one is, and it was trying to perform the call indicated by 'call_nr'
- * (READ or WRITE), release it.
- */
+  /* Check to see if any process is hanging on the pipe whose inode is in 'ip'.
+   * If one is, and it was trying to perform the call indicated by 'call_nr'
+   * (READ or WRITE), release it.
+   */
 
   register struct fproc *rp;
 
   /* Search the proc table. */
   for (rp = &fproc[0]; rp < &fproc[NR_PROCS]; rp++) {
-	if (rp->fp_suspended == SUSPENDED && (rp->fp_fd & BYTE) == call_nr &&
-				rp->fp_filp[rp->fp_fd>>8]->filp_ino == ip) {
-		revive(rp - fproc, 0);
-		susp_count--;	/* keep track of who is suspended */
-		if (--count == 0) return;
-	}
+    if (rp->fp_suspended == SUSPENDED && (rp->fp_fd & BYTE) == call_nr &&
+        rp->fp_filp[rp->fp_fd >> 8]->filp_ino == ip) {
+      revive(rp - fproc, 0);
+      susp_count--; /* keep track of who is suspended */
+      if (--count == 0)
+        return;
+    }
   }
 }
-
 
 /*===========================================================================*
  *				revive					     *
  *===========================================================================*/
 PUBLIC revive(proc_nr, bytes)
-int proc_nr;			/* process to revive */
-int bytes;			/* if hanging on task, how many bytes read */
+int proc_nr; /* process to revive */
+int bytes;   /* if hanging on task, how many bytes read */
 {
-/* Revive a previously blocked process. When a process hangs on tty, this
- * is the way it is eventually released.
- */
+  /* Revive a previously blocked process. When a process hangs on tty, this
+   * is the way it is eventually released.
+   */
 
   register struct fproc *rfp;
 
-  if (proc_nr < 0 || proc_nr >= NR_PROCS) panic("revive err", proc_nr);
+  if (proc_nr < 0 || proc_nr >= NR_PROCS)
+    panic("revive err", proc_nr);
   rfp = &fproc[proc_nr];
-  if (rfp->fp_suspended == NOT_SUSPENDED) return;
+  if (rfp->fp_suspended == NOT_SUSPENDED)
+    return;
 
   /* The 'reviving' flag only applies to pipes.  Processes waiting for TTY get
    * a message right away.  The revival process is different for TTY and pipes.
@@ -206,26 +211,24 @@ int bytes;			/* if hanging on task, how many bytes read */
    * must be restarted so it can try again.
    */
   if (rfp->fp_task == XPIPE) {
-	/* Revive a process suspended on a pipe. */
-	rfp->fp_revived = REVIVING;
-	reviving++;		/* process was waiting on pipe */
+    /* Revive a process suspended on a pipe. */
+    rfp->fp_revived = REVIVING;
+    reviving++; /* process was waiting on pipe */
   } else {
-	/* Revive a process suspended on TTY or other device. */
-	rfp->fp_suspended = NOT_SUSPENDED;
-	rfp->fp_nbytes = bytes;	/* pretend it only wants what there is */
-	reply(proc_nr, bytes);	/* unblock the process */
+    /* Revive a process suspended on TTY or other device. */
+    rfp->fp_suspended = NOT_SUSPENDED;
+    rfp->fp_nbytes = bytes; /* pretend it only wants what there is */
+    reply(proc_nr, bytes);  /* unblock the process */
   }
 }
-
 
 /*===========================================================================*
  *				do_unpause				     *
  *===========================================================================*/
-PUBLIC int do_unpause()
-{
-/* A signal has been sent to a user who is paused on the file system.
- * Abort the system call with the EINTR error message.
- */
+PUBLIC int do_unpause() {
+  /* A signal has been sent to a user who is paused on the file system.
+   * Abort the system call with the EINTR error message.
+   */
 
   register struct fproc *rfp;
   int proc_nr, task;
@@ -233,26 +236,31 @@ PUBLIC int do_unpause()
   dev_nr dev;
   extern struct filp *get_filp();
 
-  if (who > MM_PROC_NR) return(EPERM);
+  if (who > MM_PROC_NR)
+    return (EPERM);
   proc_nr = pro;
-  if (proc_nr < 0 || proc_nr >= NR_PROCS) panic("unpause err 1", proc_nr);
+  if (proc_nr < 0 || proc_nr >= NR_PROCS)
+    panic("unpause err 1", proc_nr);
   rfp = &fproc[proc_nr];
-  if (rfp->fp_suspended == NOT_SUSPENDED) return(OK);
+  if (rfp->fp_suspended == NOT_SUSPENDED)
+    return (OK);
   task = -rfp->fp_task;
 
   if (task != XPIPE) {
-	f = get_filp(rfp->fp_fd);
-	dev = f->filp_ino->i_zone[0];	/* device on which proc is hanging */
-	mess.TTY_LINE = (dev >> MINOR) & BYTE;
-	mess.PROC_NR = proc_nr;
-	mess.m_type = CANCEL;
-	if (sendrec(task, &mess) != OK) panic("unpause err 2", NO_NUM);
-	while (mess.REP_PROC_NR != proc_nr) {
-		revive(mess.REP_PROC_NR, mess.REP_STATUS);
-		if (receive(task, &m) != OK) panic("unpause err 3", NO_NUM);
-	}
-	revive(proc_nr, EINTR);	/* signal interrupted call */
+    f = get_filp(rfp->fp_fd);
+    dev = f->filp_ino->i_zone[0]; /* device on which proc is hanging */
+    mess.TTY_LINE = (dev >> MINOR) & BYTE;
+    mess.PROC_NR = proc_nr;
+    mess.m_type = CANCEL;
+    if (sendrec(task, &mess) != OK)
+      panic("unpause err 2", NO_NUM);
+    while (mess.REP_PROC_NR != proc_nr) {
+      revive(mess.REP_PROC_NR, mess.REP_STATUS);
+      if (receive(task, &m) != OK)
+        panic("unpause err 3", NO_NUM);
+    }
+    revive(proc_nr, EINTR); /* signal interrupted call */
   }
 
-  return(OK);
+  return (OK);
 }

--- a/fs/read.c
+++ b/fs/read.c
@@ -11,42 +11,38 @@
  *   read_ahead: manage the block read ahead business
  */
 
-#include "../h/const.h"
-#include "../h/type.h"
 #include "../h/com.h"
+#include "../h/const.h"
 #include "../h/error.h"
-#include "const.h"
-#include "type.h"
+#include "../h/type.h"
 #include "buf.h"
+#include "compat.h"
+#include "const.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "param.h"
 #include "super.h"
+#include "type.h"
 
-#define FD_MASK          077	/* max file descriptor is 63 */
+#define FD_MASK 077 /* max file descriptor is 63 */
 
-PRIVATE message umess;		/* message for asking SYSTASK for user copy */
-PUBLIC int rdwt_err;		/* set to EIO if disk error occurs */
+PRIVATE message umess; /* message for asking SYSTASK for user copy */
+PUBLIC int rdwt_err;   /* set to EIO if disk error occurs */
 
 /*===========================================================================*
  *				do_read					     *
  *===========================================================================*/
-PUBLIC int do_read()
-{
-  return(read_write(READING));
-}
-
-
+PUBLIC int do_read() { return (read_write(READING)); }
 
 /*===========================================================================*
  *				read_write				     *
  *===========================================================================*/
 PUBLIC int read_write(rw_flag)
-int rw_flag;			/* READING or WRITING */
+int rw_flag; /* READING or WRITING */
 {
-/* Perform read(fd, buffer, nbytes) or write(fd, buffer, nbytes) call. */
+  /* Perform read(fd, buffer, nbytes) or write(fd, buffer, nbytes) call. */
 
   register struct inode *rip;
   register struct filp *f;
@@ -60,130 +56,143 @@ int rw_flag;			/* READING or WRITING */
   extern real_time clock_time();
 
   /* MM loads segments by putting funny things in upper 10 bits of 'fd'. */
-  if (who == MM_PROC_NR && (fd & (~BYTE)) ) {
-	usr = (fd >> 8) & BYTE;
-	seg = (fd >> 6) & 03;
-	fd &= FD_MASK;		/* get rid of user and segment bits */
+  if (who == MM_PROC_NR && (fd & (~BYTE))) {
+    usr = (fd >> 8) & BYTE;
+    seg = (fd >> 6) & 03;
+    fd &= FD_MASK; /* get rid of user and segment bits */
   } else {
-	usr = who;		/* normal case */
-	seg = D;
+    usr = who; /* normal case */
+    seg = D;
   }
 
   /* If the file descriptor is valid, get the inode, size and mode. */
-  if (nbytes == 0) return(0);	/* so char special files need not check for 0*/
-  if (who != MM_PROC_NR && nbytes < 0) return(EINVAL);	/* only MM > 32K */
-  if ( (f = get_filp(fd)) == NIL_FILP) return(err_code);
-  if ( ((f->filp_mode) & (rw_flag == READING ? R_BIT : W_BIT)) == 0)
-	return(EBADF);
+  if (nbytes == 0)
+    return (0); /* so char special files need not check for 0*/
+  if (who != MM_PROC_NR && nbytes < 0)
+    return (EINVAL); /* only MM > 32K */
+  if ((f = get_filp(fd)) == NIL_FILP)
+    return (err_code);
+  if (((f->filp_mode) & (rw_flag == READING ? R_BIT : W_BIT)) == 0)
+    return (EBADF);
   position = f->filp_pos;
-  if (position < (file_pos) 0) return(EINVAL);
+  if (position < (file_pos)0)
+    return (EINVAL);
   rip = f->filp_ino;
-  f_size = rip->i_size;
+  f_size = compat_get_size(rip);
   r = OK;
   cum_io = 0;
   virg = TRUE;
   mode_word = rip->i_mode & I_TYPE;
-  if (mode_word == I_BLOCK_SPECIAL && f_size == 0) f_size = MAX_P_LONG;
-  rdwt_err = OK;		/* set to EIO if disk error occurs */
+  if (mode_word == I_BLOCK_SPECIAL && f_size == 0)
+    f_size = MAX_P_LONG;
+  rdwt_err = OK; /* set to EIO if disk error occurs */
 
   /* Check for character special files. */
   if (mode_word == I_CHAR_SPECIAL) {
-	if ((r = dev_io(rw_flag, (dev_nr) rip->i_zone[0], (long) position,
-						nbytes, who, buffer)) >= 0) {
-		cum_io = r;
-		position += r;
-		r = OK;
-	}
+    if ((r = dev_io(rw_flag, (dev_nr)rip->i_zone[0], (long)position, nbytes,
+                    who, buffer)) >= 0) {
+      cum_io = r;
+      position += r;
+      r = OK;
+    }
   } else {
-	if (rw_flag == WRITING && mode_word != I_BLOCK_SPECIAL) {
-		/* Check in advance to see if file will grow too big. */
-		if (position > get_super(rip->i_dev)->s_max_size - nbytes )
-			return(EFBIG);
+    if (rw_flag == WRITING && mode_word != I_BLOCK_SPECIAL) {
+      /* Check in advance to see if file will grow too big. */
+      if (position > get_super(rip->i_dev)->s_max_size - nbytes)
+        return (EFBIG);
 
-		/* Clear the zone containing present EOF if hole about
-		 * to be created.  This is necessary because all unwritten
-		 * blocks prior to the EOF must read as zeros.
-		 */
-		if (position > f_size) clear_zone(rip, f_size, 0);
-	}
+      /* Clear the zone containing present EOF if hole about
+       * to be created.  This is necessary because all unwritten
+       * blocks prior to the EOF must read as zeros.
+       */
+      if (position > f_size)
+        clear_zone(rip, f_size, 0);
+    }
 
-	/* Pipes are a little different.  Check. */
-	if (rip->i_pipe && (r = pipe_check(rip, rw_flag, virg,
-				nbytes, &position)) <= 0) return(r);
+    /* Pipes are a little different.  Check. */
+    if (rip->i_pipe &&
+        (r = pipe_check(rip, rw_flag, virg, nbytes, &position)) <= 0)
+      return (r);
 
-	/* Split the transfer into chunks that don't span two blocks. */
-	while (nbytes != 0) {
-		off = position % BLOCK_SIZE;	/* offset within a block */
-		chunk = MIN(nbytes, BLOCK_SIZE - off);
-		if (chunk < 0) chunk = BLOCK_SIZE - off;
+    /* Split the transfer into chunks that don't span two blocks. */
+    while (nbytes != 0) {
+      off = position % BLOCK_SIZE; /* offset within a block */
+      chunk = MIN(nbytes, BLOCK_SIZE - off);
+      if (chunk < 0)
+        chunk = BLOCK_SIZE - off;
 
-		if (rw_flag == READING) {
-			if ((bytes_left = f_size - position) <= 0)
-				break;
-			else
-				if (chunk > bytes_left) chunk = bytes_left;
-		}
+      if (rw_flag == READING) {
+        if ((bytes_left = f_size - position) <= 0)
+          break;
+        else if (chunk > bytes_left)
+          chunk = bytes_left;
+      }
 
-		/* Read or write 'chunk' bytes. */
-		r=rw_chunk(rip, position, off, chunk, rw_flag, buffer, seg,usr);
-		if (r != OK) break;	/* EOF reached */
-		if (rdwt_err < 0) break;
+      /* Read or write 'chunk' bytes. */
+      r = rw_chunk(rip, position, off, chunk, rw_flag, buffer, seg, usr);
+      if (r != OK)
+        break; /* EOF reached */
+      if (rdwt_err < 0)
+        break;
 
-		/* Update counters and pointers. */
-		buffer += chunk;	/* user buffer address */
-		nbytes -= chunk;	/* bytes yet to be read */
-		cum_io += chunk;	/* bytes read so far */
-		position += chunk;	/* position within the file */
-		virg = FALSE; /* tells pipe_check() that data has been copied */
-	}
+      /* Update counters and pointers. */
+      buffer += chunk;   /* user buffer address */
+      nbytes -= chunk;   /* bytes yet to be read */
+      cum_io += chunk;   /* bytes read so far */
+      position += chunk; /* position within the file */
+      virg = FALSE;      /* tells pipe_check() that data has been copied */
+    }
   }
 
   /* On write, update file size and access time. */
   if (rw_flag == WRITING) {
-	if (mode_word != I_CHAR_SPECIAL && mode_word != I_BLOCK_SPECIAL && 
-							position > f_size)
-		rip->i_size = position;
-	rip->i_modtime = clock_time();
-	rip->i_dirt = DIRTY;
+    if (mode_word != I_CHAR_SPECIAL && mode_word != I_BLOCK_SPECIAL &&
+        position > f_size)
+      compat_set_size(rip, position);
+    rip->i_modtime = clock_time();
+    rip->i_dirt = DIRTY;
   } else {
-	if (rip->i_pipe && position >= rip->i_size) {
-		/* Reset pipe pointers. */
-		rip->i_size = 0;	/* no data left */
-		position = 0;		/* reset reader(s) */
-		if ( (wf = find_filp(rip, W_BIT)) != NIL_FILP) wf->filp_pos = 0;
-	}
+    if (rip->i_pipe && position >= compat_get_size(rip)) {
+      /* Reset pipe pointers. */
+      compat_set_size(rip, 0); /* no data left */
+      position = 0;            /* reset reader(s) */
+      if ((wf = find_filp(rip, W_BIT)) != NIL_FILP)
+        wf->filp_pos = 0;
+    }
   }
   f->filp_pos = position;
 
   /* Check to see if read-ahead is called for, and if so, set it up. */
-  if (rw_flag == READING && rip->i_seek == NO_SEEK && position % BLOCK_SIZE == 0
-		&& (mode_word == I_REGULAR || mode_word == I_DIRECTORY)) {
-	rdahed_inode = rip;
-	rdahedpos = position;
+  if (rw_flag == READING && rip->i_seek == NO_SEEK &&
+      position % BLOCK_SIZE == 0 &&
+      (mode_word == I_REGULAR || mode_word == I_DIRECTORY)) {
+    rdahed_inode = rip;
+    rdahedpos = position;
   }
-  if (mode_word == I_REGULAR) rip->i_seek = NO_SEEK;
+  if (mode_word == I_REGULAR)
+    rip->i_seek = NO_SEEK;
 
-  if (rdwt_err != OK) r = rdwt_err;	/* check for disk error */
-  if (rdwt_err == EOF) r = cum_io;
-  return(r == OK ? cum_io : r);
+  if (rdwt_err != OK)
+    r = rdwt_err; /* check for disk error */
+  if (rdwt_err == EOF)
+    r = cum_io;
+  return (r == OK ? cum_io : r);
 }
-
-
 
 /*===========================================================================*
  *				rw_chunk				     *
  *===========================================================================*/
 PRIVATE int rw_chunk(rip, position, off, chunk, rw_flag, buff, seg, usr)
-register struct inode *rip;	/* pointer to inode for file to be rd/wr */
-file_pos position;		/* position within file to read or write */
-unsigned off;			/* off within the current block */
-int chunk;			/* number of bytes to read or write */
-int rw_flag;			/* READING or WRITING */
-char *buff;			/* virtual address of the user buffer */
-int seg;			/* T or D segment in user space */
-int usr;			/* which user process */
+register struct inode *rip; /* pointer to inode for file to be rd/wr */
+file_pos position;          /* position within file to read or write */
+unsigned off;               /* off within the current block */
+int chunk;                  /* number of bytes to read or write */
+int rw_flag;                /* READING or WRITING */
+char *buff;                 /* virtual address of the user buffer */
+int seg;                    /* T or D segment in user space */
+int usr;                    /* which user process */
 {
-/* Read or write (part of) a block. */
+  /* Read or write (part of) a block. */
 
   register struct buf *bp;
   register int r;
@@ -195,56 +204,59 @@ int usr;			/* which user process */
 
   block_spec = (rip->i_mode & I_TYPE) == I_BLOCK_SPECIAL;
   if (block_spec) {
-	b = position/BLOCK_SIZE;
-	dev = (dev_nr) rip->i_zone[0];
+    b = position / BLOCK_SIZE;
+    dev = (dev_nr)rip->i_zone[0];
   } else {
-	b = read_map(rip, position);
-	dev = rip->i_dev;
+    b = read_map(rip, position);
+    dev = rip->i_dev;
   }
 
   if (!block_spec && b == NO_BLOCK) {
-	if (rw_flag == READING) {
-		/* Reading from a nonexistent block.  Must read as all zeros. */
-		bp = get_block(NO_DEV, NO_BLOCK, NORMAL);     /* get a buffer */
-		zero_block(bp);
-	} else {
-		/* Writing to a nonexistent block. Create and enter in inode. */
-		if ((bp = new_block(rip, position)) == NIL_BUF)return(err_code);
-	}
+    if (rw_flag == READING) {
+      /* Reading from a nonexistent block.  Must read as all zeros. */
+      bp = get_block(NO_DEV, NO_BLOCK, NORMAL); /* get a buffer */
+      zero_block(bp);
+    } else {
+      /* Writing to a nonexistent block. Create and enter in inode. */
+      if ((bp = new_block(rip, position)) == NIL_BUF)
+        return (err_code);
+    }
   } else {
-	/* Normally an existing block to be partially overwritten is first read
-	 * in.  However, a full block need not be read in.  If it is already in
-	 * the cache, acquire it, otherwise just acquire a free buffer.
-	 */
-	n = (rw_flag == WRITING && chunk == BLOCK_SIZE ? NO_READ : NORMAL);
-	if(rw_flag == WRITING && off == 0 && position >= rip->i_size) n=NO_READ;
-	bp = get_block(dev, b, n);
+    /* Normally an existing block to be partially overwritten is first read
+     * in.  However, a full block need not be read in.  If it is already in
+     * the cache, acquire it, otherwise just acquire a free buffer.
+     */
+    n = (rw_flag == WRITING && chunk == BLOCK_SIZE ? NO_READ : NORMAL);
+    if (rw_flag == WRITING && off == 0 && position >= compat_get_size(rip))
+      n = NO_READ;
+    bp = get_block(dev, b, n);
   }
 
   /* In all cases, bp now points to a valid buffer. */
   if (rw_flag == WRITING && chunk != BLOCK_SIZE && !block_spec &&
-					position >= rip->i_size && off == 0)
-	zero_block(bp);
+      position >= compat_get_size(rip) && off == 0)
+    zero_block(bp);
   dir = (rw_flag == READING ? TO_USER : FROM_USER);
-  r = rw_user(seg, usr, (vir_bytes)buff, (vir_bytes)chunk, bp->b_data+off, dir);
-  if (rw_flag == WRITING) bp->b_dirt = DIRTY;
+  r = rw_user(seg, usr, (vir_bytes)buff, (vir_bytes)chunk, bp->b_data + off,
+              dir);
+  if (rw_flag == WRITING)
+    bp->b_dirt = DIRTY;
   n = (off + chunk == BLOCK_SIZE ? FULL_DATA_BLOCK : PARTIAL_DATA_BLOCK);
   put_block(bp, n);
-  return(r);
+  return (r);
 }
-
-
 
 /*===========================================================================*
  *				read_map				     *
  *===========================================================================*/
 PUBLIC block_nr read_map(rip, position)
-register struct inode *rip;	/* ptr to inode to map from */
-file_pos position;		/* position in file whose blk wanted */
+register struct inode *rip; /* ptr to inode to map from */
+file_pos position;          /* position in file whose blk wanted */
 {
-/* Given an inode and a position within the corresponding file, locate the
- * block (not zone) number in which that position is to be found and return it.
- */
+  /* Given an inode and a position within the corresponding file, locate the
+   * block (not zone) number in which that position is to be found and return
+   * it.
+   */
 
   register struct buf *bp;
   register zone_nr z;
@@ -253,101 +265,104 @@ file_pos position;		/* position in file whose blk wanted */
   register int scale, boff;
   extern struct buf *get_block();
 
-  scale = scale_factor(rip);	/* for block-zone conversion */
-  block_pos = position/BLOCK_SIZE;	/* relative blk # in file */
-  zone = block_pos >> scale;	/* position's zone */
-  boff = block_pos - (zone << scale);	/* relative blk # within zone */
+  scale = scale_factor(rip);          /* for block-zone conversion */
+  block_pos = position / BLOCK_SIZE;  /* relative blk # in file */
+  zone = block_pos >> scale;          /* position's zone */
+  boff = block_pos - (zone << scale); /* relative blk # within zone */
 
   /* Is 'position' to be found in the inode itself? */
   if (zone < NR_DZONE_NUM) {
-	if ( (z = rip->i_zone[zone]) == NO_ZONE) return(NO_BLOCK);
-	b = ((block_nr) z << scale) + boff;
-	return(b);
+    if ((z = rip->i_zone[zone]) == NO_ZONE)
+      return (NO_BLOCK);
+    b = ((block_nr)z << scale) + boff;
+    return (b);
   }
 
   /* It is not in the inode, so it must be single or double indirect. */
-  excess = zone - NR_DZONE_NUM;	/* first NR_DZONE_NUM don't count */
+  excess = zone - NR_DZONE_NUM; /* first NR_DZONE_NUM don't count */
 
   if (excess < NR_INDIRECTS) {
-	/* 'position' can be located via the single indirect block. */
-	z = rip->i_zone[NR_DZONE_NUM];
+    /* 'position' can be located via the single indirect block. */
+    z = rip->i_zone[NR_DZONE_NUM];
   } else {
-	/* 'position' can be located via the double indirect block. */
-	if ( (z = rip->i_zone[NR_DZONE_NUM+1]) == NO_ZONE) return(NO_BLOCK);
-	excess -= NR_INDIRECTS;			/* single indir doesn't count */
-	b = (block_nr) z << scale;
-	bp = get_block(rip->i_dev, b, NORMAL);	/* get double indirect block */
-	z = bp->b_ind[excess/NR_INDIRECTS];	/* z is zone # for single ind */
-	put_block(bp, INDIRECT_BLOCK);		/* release double ind block */
-	excess = excess % NR_INDIRECTS;		/* index into single ind blk */
+    /* 'position' can be located via the double indirect block. */
+    if ((z = rip->i_zone[NR_DZONE_NUM + 1]) == NO_ZONE)
+      return (NO_BLOCK);
+    excess -= NR_INDIRECTS; /* single indir doesn't count */
+    b = (block_nr)z << scale;
+    bp = get_block(rip->i_dev, b, NORMAL); /* get double indirect block */
+    z = bp->b_ind[excess / NR_INDIRECTS];  /* z is zone # for single ind */
+    put_block(bp, INDIRECT_BLOCK);         /* release double ind block */
+    excess = excess % NR_INDIRECTS;        /* index into single ind blk */
   }
 
   /* 'z' is zone number for single indirect block; 'excess' is index into it. */
-  if (z == NO_ZONE) return(NO_BLOCK);
-  b = (block_nr) z << scale;
-  bp = get_block(rip->i_dev, b, NORMAL);	/* get single indirect block */
+  if (z == NO_ZONE)
+    return (NO_BLOCK);
+  b = (block_nr)z << scale;
+  bp = get_block(rip->i_dev, b, NORMAL); /* get single indirect block */
   z = bp->b_ind[excess];
-  put_block(bp, INDIRECT_BLOCK);		/* release single indirect blk */
-  if (z == NO_ZONE) return(NO_BLOCK);
-  b = ((block_nr) z << scale) + boff;
-  return(b);
+  put_block(bp, INDIRECT_BLOCK); /* release single indirect blk */
+  if (z == NO_ZONE)
+    return (NO_BLOCK);
+  b = ((block_nr)z << scale) + boff;
+  return (b);
 }
 
 /*===========================================================================*
  *				rw_user					     *
  *===========================================================================*/
 PUBLIC int rw_user(s, u, vir, bytes, buff, direction)
-int s;				/* D or T space (stack is also D) */
-int u;				/* process number to r/w (usually = 'who') */
-vir_bytes vir;			/* virtual address to move to/from */
-vir_bytes bytes;		/* how many bytes to move */
-char *buff;			/* pointer to FS space */
-int direction;			/* TO_USER or FROM_USER */
+int s;           /* D or T space (stack is also D) */
+int u;           /* process number to r/w (usually = 'who') */
+vir_bytes vir;   /* virtual address to move to/from */
+vir_bytes bytes; /* how many bytes to move */
+char *buff;      /* pointer to FS space */
+int direction;   /* TO_USER or FROM_USER */
 {
-/* Transfer a block of data.  Two options exist, depending on 'direction':
- *     TO_USER:     Move from FS space to user virtual space
- *     FROM_USER:   Move from user virtual space to FS space
- */
+  /* Transfer a block of data.  Two options exist, depending on 'direction':
+   *     TO_USER:     Move from FS space to user virtual space
+   *     FROM_USER:   Move from user virtual space to FS space
+   */
 
-  if (direction == TO_USER ) {
-	/* Write from FS space to user space. */
-	umess.SRC_SPACE  = D;
-	umess.SRC_PROC_NR = FS_PROC_NR;
-	umess.SRC_BUFFER = (long) buff;
-	umess.DST_SPACE  = s;
-	umess.DST_PROC_NR = u;
-	umess.DST_BUFFER = (long) vir;
+  if (direction == TO_USER) {
+    /* Write from FS space to user space. */
+    umess.SRC_SPACE = D;
+    umess.SRC_PROC_NR = FS_PROC_NR;
+    umess.SRC_BUFFER = (long)buff;
+    umess.DST_SPACE = s;
+    umess.DST_PROC_NR = u;
+    umess.DST_BUFFER = (long)vir;
   } else {
-	/* Read from user space to FS space. */
-	umess.SRC_SPACE  = s;
-	umess.SRC_PROC_NR = u;
-	umess.SRC_BUFFER = (long) vir;
-	umess.DST_SPACE  = D;
-	umess.DST_PROC_NR = FS_PROC_NR;
-	umess.DST_BUFFER = (long) buff;
+    /* Read from user space to FS space. */
+    umess.SRC_SPACE = s;
+    umess.SRC_PROC_NR = u;
+    umess.SRC_BUFFER = (long)vir;
+    umess.DST_SPACE = D;
+    umess.DST_PROC_NR = FS_PROC_NR;
+    umess.DST_BUFFER = (long)buff;
   }
 
-  umess.COPY_BYTES = (long) bytes;
+  umess.COPY_BYTES = (long)bytes;
   sys_copy(&umess);
-  return(umess.m_type);
+  return (umess.m_type);
 }
-
 
 /*===========================================================================*
  *				read_ahead				     *
  *===========================================================================*/
-PUBLIC read_ahead()
-{
-/* Read a block into the cache before it is needed. */
+PUBLIC read_ahead() {
+  /* Read a block into the cache before it is needed. */
 
   register struct inode *rip;
   struct buf *bp;
   block_nr b;
   extern struct buf *get_block();
 
-  rip = rdahed_inode;		/* pointer to inode to read ahead from */
-  rdahed_inode = NIL_INODE;	/* turn off read ahead */
-  if ( (b = read_map(rip, rdahedpos)) == NO_BLOCK) return;	/* at EOF */
+  rip = rdahed_inode;       /* pointer to inode to read ahead from */
+  rdahed_inode = NIL_INODE; /* turn off read ahead */
+  if ((b = read_map(rip, rdahedpos)) == NO_BLOCK)
+    return; /* at EOF */
   bp = get_block(rip->i_dev, b, NORMAL);
   put_block(bp, PARTIAL_DATA_BLOCK);
 }

--- a/fs/stadir.c
+++ b/fs/stadir.c
@@ -9,100 +9,98 @@
  */
 
 #include "../h/const.h"
-#include "../h/type.h"
 #include "../h/error.h"
 #include "../h/stat.h"
+#include "../h/type.h"
+#include "compat.h"
 #include "const.h"
-#include "type.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "param.h"
+#include "type.h"
 
 /*===========================================================================*
  *				do_chdir				     *
  *===========================================================================*/
-PUBLIC int do_chdir()
-{
-/* Change directory.  This function is  also called by MM to simulate a chdir
- * in order to do EXEC, etc.
- */
+PUBLIC int do_chdir() {
+  /* Change directory.  This function is  also called by MM to simulate a chdir
+   * in order to do EXEC, etc.
+   */
 
   register struct fproc *rfp;
 
   if (who == MM_PROC_NR) {
-	rfp = &fproc[slot1];
-	put_inode(fp->fp_workdir);
-	fp->fp_workdir = (cd_flag ? fp->fp_rootdir : rfp->fp_workdir);
-	dup_inode(fp->fp_workdir);
-	fp->fp_effuid = (cd_flag ? SUPER_USER : rfp->fp_effuid);
-	return(OK);
+    rfp = &fproc[slot1];
+    put_inode(fp->fp_workdir);
+    fp->fp_workdir = (cd_flag ? fp->fp_rootdir : rfp->fp_workdir);
+    dup_inode(fp->fp_workdir);
+    fp->fp_effuid = (cd_flag ? SUPER_USER : rfp->fp_effuid);
+    return (OK);
   }
 
-/* Perform the chdir(name) system call. */
+  /* Perform the chdir(name) system call. */
   return change(&fp->fp_workdir, name, name_length);
 }
-
 
 /*===========================================================================*
  *				do_chroot				     *
  *===========================================================================*/
-PUBLIC int do_chroot()
-{
-/* Perform the chroot(name) system call. */
+PUBLIC int do_chroot() {
+  /* Perform the chroot(name) system call. */
 
   register int r;
 
-  if (!super_user) return(EPERM);	/* only su may chroot() */
+  if (!super_user)
+    return (EPERM); /* only su may chroot() */
   r = change(&fp->fp_rootdir, name, name_length);
-  return(r);
+  return (r);
 }
-
 
 /*===========================================================================*
  *				change					     *
  *===========================================================================*/
 PRIVATE int change(iip, name_ptr, len)
-struct inode **iip;		/* pointer to the inode pointer for the dir */
-char *name_ptr;			/* pointer to the directory name to change to */
-int len;			/* length of the directory name string */
+struct inode **iip; /* pointer to the inode pointer for the dir */
+char *name_ptr;     /* pointer to the directory name to change to */
+int len;            /* length of the directory name string */
 {
-/* Do the actual work for chdir() and chroot(). */
+  /* Do the actual work for chdir() and chroot(). */
 
   struct inode *rip;
   register int r;
   extern struct inode *eat_path();
 
   /* Try to open the new directory. */
-  if (fetch_name(name_ptr, len, M3) != OK) return(err_code);
-  if ( (rip = eat_path(user_path)) == NIL_INODE) return(err_code);
+  if (fetch_name(name_ptr, len, M3) != OK)
+    return (err_code);
+  if ((rip = eat_path(user_path)) == NIL_INODE)
+    return (err_code);
 
   /* It must be a directory and also be searchable. */
-  if ( (rip->i_mode & I_TYPE) != I_DIRECTORY)
-	r = ENOTDIR;
+  if ((rip->i_mode & I_TYPE) != I_DIRECTORY)
+    r = ENOTDIR;
   else
-	r = forbidden(rip, X_BIT, 0);	/* check if dir is searchable */
+    r = forbidden(rip, X_BIT, 0); /* check if dir is searchable */
 
   /* If error, return inode. */
   if (r != OK) {
-	put_inode(rip);
-	return(r);
+    put_inode(rip);
+    return (r);
   }
 
   /* Everything is OK.  Make the change. */
-  put_inode(*iip);		/* release the old directory */
-  *iip = rip;			/* acquire the new one */
-  return(OK);
+  put_inode(*iip); /* release the old directory */
+  *iip = rip;      /* acquire the new one */
+  return (OK);
 }
-
 
 /*===========================================================================*
  *				do_stat					     *
  *===========================================================================*/
-PUBLIC int do_stat()
-{
-/* Perform the stat(name, buf) system call. */
+PUBLIC int do_stat() {
+  /* Perform the stat(name, buf) system call. */
 
   register struct inode *rip;
   register int r;
@@ -111,40 +109,40 @@ PUBLIC int do_stat()
   /* Both stat() and fstat() use the same routine to do the real work.  That
    * routine expects an inode, so acquire it temporarily.
    */
-  if (fetch_name(name1, name1_length, M1) != OK) return(err_code);
-  if ( (rip = eat_path(user_path)) == NIL_INODE) return(err_code);
-  r = stat_inode(rip, NIL_FILP, name2);	/* actually do the work.*/
-  put_inode(rip);		/* release the inode */
-  return(r);
+  if (fetch_name(name1, name1_length, M1) != OK)
+    return (err_code);
+  if ((rip = eat_path(user_path)) == NIL_INODE)
+    return (err_code);
+  r = stat_inode(rip, NIL_FILP, name2); /* actually do the work.*/
+  put_inode(rip);                       /* release the inode */
+  return (r);
 }
-
 
 /*===========================================================================*
  *				do_fstat				     *
  *===========================================================================*/
-PUBLIC int do_fstat()
-{
-/* Perform the fstat(fd, buf) system call. */
+PUBLIC int do_fstat() {
+  /* Perform the fstat(fd, buf) system call. */
 
   register struct filp *rfilp;
   extern struct filp *get_filp();
 
   /* Is the file descriptor valid? */
-  if ( (rfilp = get_filp(fd)) == NIL_FILP) return(err_code);
+  if ((rfilp = get_filp(fd)) == NIL_FILP)
+    return (err_code);
 
-  return(stat_inode(rfilp->filp_ino, rfilp, buffer));
+  return (stat_inode(rfilp->filp_ino, rfilp, buffer));
 }
-
 
 /*===========================================================================*
  *				stat_inode				     *
  *===========================================================================*/
 PRIVATE int stat_inode(rip, fil_ptr, user_addr)
-register struct inode *rip;	/* pointer to inode to stat */
-struct filp *fil_ptr;		/* filp pointer, supplied by 'fstat' */
-char *user_addr;			/* user space address where stat buf goes */
+register struct inode *rip; /* pointer to inode to stat */
+struct filp *fil_ptr;       /* filp pointer, supplied by 'fstat' */
+char *user_addr;            /* user space address where stat buf goes */
 {
-/* Common code for stat and fstat system calls. */
+  /* Common code for stat and fstat system calls. */
 
   register struct stat *stp;
   struct stat statbuf;
@@ -152,25 +150,25 @@ char *user_addr;			/* user space address where stat buf goes */
   vir_bytes v;
 
   /* Fill in the statbuf struct. */
-  stp = &statbuf;		/* set up pointer to the buffer */
-  stp->st_dev = (int) rip->i_dev;
+  stp = &statbuf; /* set up pointer to the buffer */
+  stp->st_dev = (int)rip->i_dev;
   stp->st_ino = rip->i_num;
   stp->st_mode = rip->i_mode;
   stp->st_nlink = rip->i_nlinks & BYTE;
   stp->st_uid = rip->i_uid;
   stp->st_gid = rip->i_gid & BYTE;
   stp->st_rdev = rip->i_zone[0];
-  stp->st_size = rip->i_size;
-  if (	(rip->i_pipe == I_PIPE) &&	/* IF it is a pipe */
-	(fil_ptr != NIL_FILP) &&	/* AND it was fstat */
-	(fil_ptr->filp_mode == R_BIT))	/* on the reading end, */
-	stp->st_size -= fil_ptr->filp_pos; /* adjust the visible size. */
+  stp->st_size = (long)compat_get_size(rip);
+  if ((rip->i_pipe == I_PIPE) &&       /* IF it is a pipe */
+      (fil_ptr != NIL_FILP) &&         /* AND it was fstat */
+      (fil_ptr->filp_mode == R_BIT))   /* on the reading end, */
+    stp->st_size -= fil_ptr->filp_pos; /* adjust the visible size. */
   stp->st_atime = rip->i_modtime;
   stp->st_mtime = rip->i_modtime;
   stp->st_ctime = rip->i_modtime;
 
   /* Copy the struct to user space. */
-  v = (vir_bytes) user_addr;
-  r = rw_user(D, who, v, (vir_bytes) sizeof statbuf, (char *) stp, TO_USER);
-  return(r);
+  v = (vir_bytes)user_addr;
+  r = rw_user(D, who, v, (vir_bytes)sizeof statbuf, (char *)stp, TO_USER);
+  return (r);
 }

--- a/fs/super.h
+++ b/fs/super.h
@@ -1,7 +1,7 @@
 /* Super block table.  The root file system and every mounted file system
  * has an entry here.  The entry holds information about the sizes of the bit
  * maps and inodes.  The s_ninodes field gives the number of inodes available
- * for files and directories, including the root directory.  Inode 0 is 
+ * for files and directories, including the root directory.  Inode 0 is
  * on the disk, but not used.  Thus s_ninodes = 4 means that 5 bits will be
  * used in the bit map, bit 0, which is always 1 and not used, and bits 1-4
  * for files and directories.  The disk layout is:
@@ -15,29 +15,29 @@
  *    unused        whatever is needed to fill out the current zone
  *    data zones    (s_nzones - s_firstdatazone) << s_log_zone_size
  *
- * A super_block slot is free if s_dev == NO_DEV. 
+ * A super_block slot is free if s_dev == NO_DEV.
  */
 
-
 EXTERN struct super_block {
-  inode_nr s_ninodes;		/* # usable inodes on the minor device */
-  zone_nr s_nzones;		/* total device size, including bit maps etc */
-  unshort s_imap_blocks;	/* # of blocks used by inode bit map */
-  unshort s_zmap_blocks;	/* # of blocks used by zone bit map */
-  zone_nr s_firstdatazone;	/* number of first data zone */
-  short int s_log_zone_size;	/* log2 of blocks/zone */
-  file_pos s_max_size;		/* maximum file size on this device */
-  int s_magic;			/* magic number to recognize super-blocks */
+  inode_nr s_ninodes;        /* # usable inodes on the minor device */
+  zone_nr s_nzones;          /* total device size, including bit maps etc */
+  unshort s_imap_blocks;     /* # of blocks used by inode bit map */
+  unshort s_zmap_blocks;     /* # of blocks used by zone bit map */
+  zone_nr s_firstdatazone;   /* number of first data zone */
+  short int s_log_zone_size; /* log2 of blocks/zone */
+  file_pos s_max_size;       /* maximum file size on this device */
+  file_pos64 s_max_size64;   /* 64-bit maximum file size */
+  int s_magic;               /* magic number to recognize super-blocks */
 
   /* The following items are only used when the super_block is in memory. */
   struct buf *s_imap[I_MAP_SLOTS]; /* pointers to the in-core inode bit map */
-  struct buf *s_zmap[ZMAP_SLOTS]; /* pointers to the in-core zone bit map */
-  dev_nr s_dev;			/* whose super block is this? */
-  struct inode *s_isup;		/* inode for root dir of mounted file sys */
-  struct inode *s_imount;	/* inode mounted on */
-  real_time s_time;		/* time of last update */
-  char s_rd_only;		/* set to 1 iff file sys mounted read only */
-  char s_dirt;			/* CLEAN or DIRTY */
+  struct buf *s_zmap[ZMAP_SLOTS];  /* pointers to the in-core zone bit map */
+  dev_nr s_dev;                    /* whose super block is this? */
+  struct inode *s_isup;            /* inode for root dir of mounted file sys */
+  struct inode *s_imount;          /* inode mounted on */
+  real_time s_time;                /* time of last update */
+  char s_rd_only;                  /* set to 1 iff file sys mounted read only */
+  char s_dirt;                     /* CLEAN or DIRTY */
 } super_block[NR_SUPERS];
 
-#define NIL_SUPER (struct super_block *) 0
+#define NIL_SUPER (struct super_block *)0

--- a/fs/type.h
+++ b/fs/type.h
@@ -1,17 +1,18 @@
 /* Type definitions local to the File System. */
 
-typedef struct {		/* directory entry */
-  inode_nr d_inum;		/* inode number */
-  char d_name[NAME_SIZE];	/* character string */
+typedef struct {          /* directory entry */
+  inode_nr d_inum;        /* inode number */
+  char d_name[NAME_SIZE]; /* character string */
 } dir_struct;
 
 /* Declaration of the disk inode used in rw_inode(). */
-typedef struct {		/* disk inode.  Memory inode is in "inotab.h" */
-  mask_bits i_mode;		/* file type, protection, etc. */
-  uid i_uid;			/* user id of the file's owner */
-  file_pos i_size;		/* current file size in bytes */
-  real_time i_modtime;		/* when was file data last changed */
-  gid i_gid;			/* group number */
-  links i_nlinks;		/* how many links to this file */
-  zone_nr i_zone[NR_ZONE_NUMS];	/* block nums for direct, ind, and dbl ind */
+typedef struct {                /* disk inode.  Memory inode is in "inotab.h" */
+  mask_bits i_mode;             /* file type, protection, etc. */
+  uid i_uid;                    /* user id of the file's owner */
+  file_pos i_size;              /* current file size in bytes */
+  file_pos64 i_size64;          /* 64-bit file size */
+  real_time i_modtime;          /* when was file data last changed */
+  gid i_gid;                    /* group number */
+  links i_nlinks;               /* how many links to this file */
+  zone_nr i_zone[NR_ZONE_NUMS]; /* block nums for direct, ind, and dbl ind */
 } d_inode;

--- a/fs/write.c
+++ b/fs/write.c
@@ -9,36 +9,35 @@
  */
 
 #include "../h/const.h"
-#include "../h/type.h"
 #include "../h/error.h"
-#include "const.h"
-#include "type.h"
+#include "../h/type.h"
 #include "buf.h"
+#include "compat.h"
+#include "const.h"
 #include "file.h"
 #include "fproc.h"
 #include "glo.h"
 #include "inode.h"
 #include "super.h"
+#include "type.h"
 
 /*===========================================================================*
  *				do_write				     *
  *===========================================================================*/
-PUBLIC int do_write()
-{
-/* Perform the write(fd, buffer, nbytes) system call. */
-  return(read_write(WRITING));
+PUBLIC int do_write() {
+  /* Perform the write(fd, buffer, nbytes) system call. */
+  return (read_write(WRITING));
 }
-
 
 /*===========================================================================*
  *				write_map				     *
  *===========================================================================*/
 PRIVATE int write_map(rip, position, new_zone)
-register struct inode *rip;	/* pointer to inode to be changed */
-file_pos position;		/* file address to be mapped */
-zone_nr new_zone;		/* zone # to be inserted */
+register struct inode *rip; /* pointer to inode to be changed */
+file_pos position;          /* file address to be mapped */
+zone_nr new_zone;           /* zone # to be inserted */
 {
-/* Write a new zone into an inode. */
+  /* Write a new zone into an inode. */
   int scale;
   zone_nr z, *zp;
   register block_nr b;
@@ -51,84 +50,88 @@ zone_nr new_zone;		/* zone # to be inserted */
   extern struct buf *get_block();
   extern real_time clock_time();
 
-  rip->i_dirt = DIRTY;		/* inode will be changed */
+  rip->i_dirt = DIRTY; /* inode will be changed */
   bp = NIL_BUF;
-  scale = scale_factor(rip);	/* for zone-block conversion */
-  zone = (position/BLOCK_SIZE) >> scale;	/* relative zone # to insert */
+  scale = scale_factor(rip);               /* for zone-block conversion */
+  zone = (position / BLOCK_SIZE) >> scale; /* relative zone # to insert */
 
   /* Is 'position' to be found in the inode itself? */
   if (zone < NR_DZONE_NUM) {
-	rip->i_zone[zone] = new_zone;
-	rip->i_modtime = clock_time();
-	return(OK);
+    rip->i_zone[zone] = new_zone;
+    rip->i_modtime = clock_time();
+    return (OK);
   }
 
   /* It is not in the inode, so it must be single or double indirect. */
-  excess = zone - NR_DZONE_NUM;	/* first NR_DZONE_NUM don't count */
+  excess = zone - NR_DZONE_NUM; /* first NR_DZONE_NUM don't count */
   new_ind = FALSE;
   new_dbl = FALSE;
 
   if (excess < NR_INDIRECTS) {
-	/* 'position' can be located via the single indirect block. */
-	zp = &rip->i_zone[NR_DZONE_NUM];
+    /* 'position' can be located via the single indirect block. */
+    zp = &rip->i_zone[NR_DZONE_NUM];
   } else {
-	/* 'position' can be located via the double indirect block. */
-	if ( (z = rip->i_zone[NR_DZONE_NUM+1]) == NO_ZONE) {
-		/* Create the double indirect block. */
-		if ( (z = alloc_zone(rip->i_dev, rip->i_zone[0])) == NO_ZONE)
-			return(err_code);
-		rip->i_zone[NR_DZONE_NUM+1] = z;
-		new_dbl = TRUE;	/* set flag for later */
-	}
+    /* 'position' can be located via the double indirect block. */
+    if ((z = rip->i_zone[NR_DZONE_NUM + 1]) == NO_ZONE) {
+      /* Create the double indirect block. */
+      if ((z = alloc_zone(rip->i_dev, rip->i_zone[0])) == NO_ZONE)
+        return (err_code);
+      rip->i_zone[NR_DZONE_NUM + 1] = z;
+      new_dbl = TRUE; /* set flag for later */
+    }
 
-	/* Either way, 'z' is zone number for double indirect block. */
-	excess -= NR_INDIRECTS;	/* single indirect doesn't count */
-	index = excess / NR_INDIRECTS;
-	excess = excess % NR_INDIRECTS;
-	if (index >= NR_INDIRECTS) return(EFBIG);
-	b = (block_nr) z << scale;
-	bp = get_block(rip->i_dev, b, (new_dbl ? NO_READ : NORMAL));
-	if (new_dbl) zero_block(bp);
-	zp= &bp->b_ind[index];
+    /* Either way, 'z' is zone number for double indirect block. */
+    excess -= NR_INDIRECTS; /* single indirect doesn't count */
+    index = excess / NR_INDIRECTS;
+    excess = excess % NR_INDIRECTS;
+    if (index >= NR_INDIRECTS)
+      return (EFBIG);
+    b = (block_nr)z << scale;
+    bp = get_block(rip->i_dev, b, (new_dbl ? NO_READ : NORMAL));
+    if (new_dbl)
+      zero_block(bp);
+    zp = &bp->b_ind[index];
   }
 
   /* 'zp' now points to place where indirect zone # goes; 'excess' is index. */
   if (*zp == NO_ZONE) {
-	/* Create indirect block. */
-	*zp = alloc_zone(rip->i_dev, rip->i_zone[0]);
-	new_ind = TRUE;
-	if (bp != NIL_BUF) bp->b_dirt = DIRTY;	/* if double ind, it is dirty */
-	if (*zp == NO_ZONE) {
-		put_block(bp, INDIRECT_BLOCK);	/* release dbl indirect blk */
-		return(err_code);	/* couldn't create single ind */
-	}
+    /* Create indirect block. */
+    *zp = alloc_zone(rip->i_dev, rip->i_zone[0]);
+    new_ind = TRUE;
+    if (bp != NIL_BUF)
+      bp->b_dirt = DIRTY; /* if double ind, it is dirty */
+    if (*zp == NO_ZONE) {
+      put_block(bp, INDIRECT_BLOCK); /* release dbl indirect blk */
+      return (err_code);             /* couldn't create single ind */
+    }
   }
-  put_block(bp, INDIRECT_BLOCK);	/* release double indirect blk */
+  put_block(bp, INDIRECT_BLOCK); /* release double indirect blk */
 
   /* 'zp' now points to indirect block's zone number. */
-  b = (block_nr) *zp << scale;
-  bp = get_block(rip->i_dev, b, (new_ind ? NO_READ : NORMAL) );
-  if (new_ind) zero_block(bp);
+  b = (block_nr)*zp << scale;
+  bp = get_block(rip->i_dev, b, (new_ind ? NO_READ : NORMAL));
+  if (new_ind)
+    zero_block(bp);
   bp->b_ind[excess] = new_zone;
   rip->i_modtime = clock_time();
   bp->b_dirt = DIRTY;
   put_block(bp, INDIRECT_BLOCK);
 
-  return(OK);
+  return (OK);
 }
 
 /*===========================================================================*
  *				clear_zone				     *
  *===========================================================================*/
 PUBLIC clear_zone(rip, pos, flag)
-register struct inode *rip;	/* inode to clear */
-file_pos pos;			/* points to block to clear */
-int flag;			/* 0 if called by read_write, 1 by new_block */
+register struct inode *rip; /* inode to clear */
+file_pos pos;               /* points to block to clear */
+int flag;                   /* 0 if called by read_write, 1 by new_block */
 {
-/* Zero a zone, possibly starting in the middle.  The parameter 'pos' gives
- * a byte in the first block to be zeroed.  Clearzone() is called from 
- * read_write and new_block().
- */
+  /* Zero a zone, possibly starting in the middle.  The parameter 'pos' gives
+   * a byte in the first block to be zeroed.  Clearzone() is called from
+   * read_write and new_block().
+   */
 
   register struct buf *bp;
   register block_nr b, blo, bhi;
@@ -139,38 +142,40 @@ int flag;			/* 0 if called by read_write, 1 by new_block */
   extern block_nr read_map();
 
   /* If the block size and zone size are the same, clear_zone() not needed. */
-  if ( (scale = scale_factor(rip)) == 0) return;
+  if ((scale = scale_factor(rip)) == 0)
+    return;
 
-
-  zone_size = (zone_type) BLOCK_SIZE << scale;
-  if (flag == 1) pos = (pos/zone_size) * zone_size;
+  zone_size = (zone_type)BLOCK_SIZE << scale;
+  if (flag == 1)
+    pos = (pos / zone_size) * zone_size;
   next = pos + BLOCK_SIZE - 1;
 
   /* If 'pos' is in the last block of a zone, do not clear the zone. */
-  if (next/zone_size != pos/zone_size) return;
-  if ( (blo = read_map(rip, next)) == NO_BLOCK) return;
-  bhi = (  ((blo>>scale)+1) << scale)   - 1;
+  if (next / zone_size != pos / zone_size)
+    return;
+  if ((blo = read_map(rip, next)) == NO_BLOCK)
+    return;
+  bhi = (((blo >> scale) + 1) << scale) - 1;
 
   /* Clear all the blocks between 'blo' and 'bhi'. */
   for (b = blo; b <= bhi; b++) {
-	bp = get_block(rip->i_dev, b, NO_READ);
-	zero_block(bp);
-	put_block(bp, FULL_DATA_BLOCK);
+    bp = get_block(rip->i_dev, b, NO_READ);
+    zero_block(bp);
+    put_block(bp, FULL_DATA_BLOCK);
   }
 }
-
 
 /*===========================================================================*
  *				new_block				     *
  *===========================================================================*/
 PUBLIC struct buf *new_block(rip, position)
-register struct inode *rip;	/* pointer to inode */
-file_pos position;		/* file pointer */
+register struct inode *rip; /* pointer to inode */
+file_pos position;          /* file pointer */
 {
-/* Acquire a new block and return a pointer to it.  Doing so may require
- * allocating a complete zone, and then returning the initial block.
- * On the other hand, the current zone may still have some unused blocks.
- */
+  /* Acquire a new block and return a pointer to it.  Doing so may require
+   * allocating a complete zone, and then returning the initial block.
+   * On the other hand, the current zone may still have some unused blocks.
+   */
 
   register struct buf *bp;
   block_nr b, base_block;
@@ -184,49 +189,52 @@ file_pos position;		/* file pointer */
   extern zone_nr alloc_zone();
 
   /* Is another block available in the current zone? */
-  if ( (b = read_map(rip, position)) == NO_BLOCK) {
-	/* Choose first zone if need be. */
-	if (rip->i_size == 0) {
-		sp = get_super(rip->i_dev);
-		z = sp->s_firstdatazone;
-	} else {
-		z = rip->i_zone[0];
-	}
-	if ( (z = alloc_zone(rip->i_dev, z)) == NO_ZONE) return(NIL_BUF);
-	if ( (r = write_map(rip, position, z)) != OK) {
-		free_zone(rip->i_dev, z);
-		err_code = r;
-		return(NIL_BUF);
-	}
+  if ((b = read_map(rip, position)) == NO_BLOCK) {
+    /* Choose first zone if need be. */
+    if (compat_get_size(rip) == 0) {
+      sp = get_super(rip->i_dev);
+      z = sp->s_firstdatazone;
+    } else {
+      z = rip->i_zone[0];
+    }
+    if ((z = alloc_zone(rip->i_dev, z)) == NO_ZONE)
+      return (NIL_BUF);
+    if ((r = write_map(rip, position, z)) != OK) {
+      free_zone(rip->i_dev, z);
+      err_code = r;
+      return (NIL_BUF);
+    }
 
-	/* If we are not writing at EOF, clear the zone, just to be safe. */
-	if ( position != rip->i_size) clear_zone(rip, position, 1);
-	scale = scale_factor(rip);
-	base_block = (block_nr) z << scale;
-	zone_size = (zone_type) BLOCK_SIZE << scale;
-	b = base_block + (block_nr)((position % zone_size)/BLOCK_SIZE);
+    /* If we are not writing at EOF, clear the zone, just to be safe. */
+    if (position != compat_get_size(rip))
+      clear_zone(rip, position, 1);
+    scale = scale_factor(rip);
+    base_block = (block_nr)z << scale;
+    zone_size = (zone_type)BLOCK_SIZE << scale;
+    b = base_block + (block_nr)((position % zone_size) / BLOCK_SIZE);
   }
 
   bp = get_block(rip->i_dev, b, NO_READ);
   zero_block(bp);
-  return(bp);
+  return (bp);
 }
-
 
 /*===========================================================================*
  *				zero_block				     *
  *===========================================================================*/
 PUBLIC zero_block(bp)
-register struct buf *bp;	/* pointer to buffer to zero */
+register struct buf *bp; /* pointer to buffer to zero */
 {
-/* Zero a block. */
+  /* Zero a block. */
 
   register int n;
   register int *zip;
 
-  n = INTS_PER_BLOCK;		/* number of integers in a block */
-  zip = bp->b_int;		/* where to start clearing */
+  n = INTS_PER_BLOCK; /* number of integers in a block */
+  zip = bp->b_int;    /* where to start clearing */
 
-  do { *zip++ = 0;}  while (--n);
+  do {
+    *zip++ = 0;
+  } while (--n);
   bp->b_dirt = DIRTY;
 }

--- a/h/type.h
+++ b/h/type.h
@@ -1,125 +1,147 @@
 /* Macros */
-#define MAX(a,b)	(a > b ? a : b)
-#define MIN(a,b)	(a < b ? a : b)
+#define MAX(a, b) (a > b ? a : b)
+#define MIN(a, b) (a < b ? a : b)
 
 /* Type definitions */
-typedef unsigned short unshort;	/* must be 16-bit unsigned */
-typedef unshort block_nr;	/* block number */
-#define NO_BLOCK (block_nr) 0	/* indicates the absence of a block number */
-#define MAX_BLOCK_NR (block_nr) 0177777
+typedef unsigned short unshort; /* must be 16-bit unsigned */
+typedef unshort block_nr;       /* block number */
+#define NO_BLOCK (block_nr)0    /* indicates the absence of a block number */
+#define MAX_BLOCK_NR (block_nr)0177777
 
-typedef unshort inode_nr;	/* inode number */
-#define NO_ENTRY (inode_nr) 0	/* indicates the absence of a dir entry */
-#define MAX_INODE_NR (inode_nr) 0177777
+typedef unshort inode_nr;    /* inode number */
+#define NO_ENTRY (inode_nr)0 /* indicates the absence of a dir entry */
+#define MAX_INODE_NR (inode_nr)0177777
 
-typedef unshort zone_nr;	/* zone number */
-#define NO_ZONE   (zone_nr) 0	/* indicates the absence of a zone number */
-#define HIGHEST_ZONE (zone_nr)  0177777
+typedef unshort zone_nr;   /* zone number */
+#define NO_ZONE (zone_nr)0 /* indicates the absence of a zone number */
+#define HIGHEST_ZONE (zone_nr)0177777
 
-typedef unshort bit_nr;		/* if inode_nr & zone_nr both unshort,
-				   then also unshort, else long */
+typedef unshort bit_nr; /* if inode_nr & zone_nr both unshort,
+                           then also unshort, else long */
 
-typedef long zone_type;		/* zone size */
-typedef unshort mask_bits;	/* mode bits */
-typedef unshort dev_nr;		/* major | minor device number */
-#define NO_DEV    (dev_nr) ~0	/* indicates absence of a device number */
+typedef long zone_type;    /* zone size */
+typedef unshort mask_bits; /* mode bits */
+typedef unshort dev_nr;    /* major | minor device number */
+#define NO_DEV (dev_nr) ~0 /* indicates absence of a device number */
 
-typedef char links;		/* number of links to an inode */
-#define MAX_LINKS 	0177
+typedef char links; /* number of links to an inode */
+#define MAX_LINKS 0177
 
-typedef long real_time;		/* real time in seconds since Jan 1, 1980 */
-typedef long file_pos;		/* position in, or length of, a file */
+typedef long real_time; /* real time in seconds since Jan 1, 1980 */
+typedef long file_pos;  /* position in, or length of, a file */
 #define MAX_FILE_POS 017777777777L
-typedef short int uid;		/* user id */
-typedef char gid;		/* group id */
+typedef long long file_pos64; /* 64-bit file positions */
+#define MAX_FILE_POS64 0x7fffffffffffffffLL
+typedef short int uid; /* user id */
+typedef char gid;      /* group id */
 
-typedef unsigned vir_bytes;	/* virtual addresses and lengths in bytes */
-typedef unsigned vir_clicks;	/* virtual addresses and lengths in clicks */
-typedef long phys_bytes;	/* physical addresses and lengths in bytes */
-typedef unsigned phys_clicks;	/* physical addresses and lengths in clicks */
-typedef int signed_clicks;	/* same length as phys_clicks, but signed */
+typedef unsigned vir_bytes;   /* virtual addresses and lengths in bytes */
+typedef unsigned vir_clicks;  /* virtual addresses and lengths in clicks */
+typedef long phys_bytes;      /* physical addresses and lengths in bytes */
+typedef unsigned phys_clicks; /* physical addresses and lengths in clicks */
+typedef int signed_clicks;    /* same length as phys_clicks, but signed */
 
 /* Types relating to messages. */
-#define M1                 1
-#define M3                 3
-#define M4                 4
-#define M3_STRING         14
-
-typedef struct {int m1i1, m1i2, m1i3; char *m1p1, *m1p2, *m1p3;} mess_1;
-typedef struct {int m2i1, m2i2, m2i3; long m2l1, m2l2; char *m2p1;} mess_2;
-typedef struct {int m3i1, m3i2; char *m3p1; char m3ca1[M3_STRING];} mess_3;
-typedef struct {long m4l1, m4l2, m4l3, m4l4;} mess_4;
-typedef struct {char m5c1, m5c2; int m5i1, m5i2; long m5l1, m5l2, m5l3;} mess_5;
-typedef struct {int m6i1, m6i2, m6i3; long m6l1; int (*m6f1)();} mess_6;
+#define M1 1
+#define M3 3
+#define M4 4
+#define M3_STRING 14
 
 typedef struct {
-  int m_source;			/* who sent the message */
-  int m_type;			/* what kind of message is it */
+  int m1i1, m1i2, m1i3;
+  char *m1p1, *m1p2, *m1p3;
+} mess_1;
+typedef struct {
+  int m2i1, m2i2, m2i3;
+  long m2l1, m2l2;
+  char *m2p1;
+} mess_2;
+typedef struct {
+  int m3i1, m3i2;
+  char *m3p1;
+  char m3ca1[M3_STRING];
+} mess_3;
+typedef struct {
+  long m4l1, m4l2, m4l3, m4l4;
+} mess_4;
+typedef struct {
+  char m5c1, m5c2;
+  int m5i1, m5i2;
+  long m5l1, m5l2, m5l3;
+} mess_5;
+typedef struct {
+  int m6i1, m6i2, m6i3;
+  long m6l1;
+  int (*m6f1)();
+} mess_6;
+
+typedef struct {
+  int m_source; /* who sent the message */
+  int m_type;   /* what kind of message is it */
   union {
-	mess_1 m_m1;
-	mess_2 m_m2;
-	mess_3 m_m3;
-	mess_4 m_m4;
-	mess_5 m_m5;
-	mess_6 m_m6;
+    mess_1 m_m1;
+    mess_2 m_m2;
+    mess_3 m_m3;
+    mess_4 m_m4;
+    mess_5 m_m5;
+    mess_6 m_m6;
   } m_u;
 } message;
 
 #define MESS_SIZE (sizeof(message))
-#define NIL_MESS (message *) 0
+#define NIL_MESS (message *)0
 
 /* The following defines provide names for useful members. */
-#define m1_i1  m_u.m_m1.m1i1
-#define m1_i2  m_u.m_m1.m1i2
-#define m1_i3  m_u.m_m1.m1i3
-#define m1_p1  m_u.m_m1.m1p1
-#define m1_p2  m_u.m_m1.m1p2
-#define m1_p3  m_u.m_m1.m1p3
+#define m1_i1 m_u.m_m1.m1i1
+#define m1_i2 m_u.m_m1.m1i2
+#define m1_i3 m_u.m_m1.m1i3
+#define m1_p1 m_u.m_m1.m1p1
+#define m1_p2 m_u.m_m1.m1p2
+#define m1_p3 m_u.m_m1.m1p3
 
-#define m2_i1  m_u.m_m2.m2i1
-#define m2_i2  m_u.m_m2.m2i2
-#define m2_i3  m_u.m_m2.m2i3
-#define m2_l1  m_u.m_m2.m2l1
-#define m2_l2  m_u.m_m2.m2l2
-#define m2_p1  m_u.m_m2.m2p1
+#define m2_i1 m_u.m_m2.m2i1
+#define m2_i2 m_u.m_m2.m2i2
+#define m2_i3 m_u.m_m2.m2i3
+#define m2_l1 m_u.m_m2.m2l1
+#define m2_l2 m_u.m_m2.m2l2
+#define m2_p1 m_u.m_m2.m2p1
 
-#define m3_i1  m_u.m_m3.m3i1
-#define m3_i2  m_u.m_m3.m3i2
-#define m3_p1  m_u.m_m3.m3p1
+#define m3_i1 m_u.m_m3.m3i1
+#define m3_i2 m_u.m_m3.m3i2
+#define m3_p1 m_u.m_m3.m3p1
 #define m3_ca1 m_u.m_m3.m3ca1
 
+#define m4_l1 m_u.m_m4.m4l1
+#define m4_l2 m_u.m_m4.m4l2
+#define m4_l3 m_u.m_m4.m4l3
+#define m4_l4 m_u.m_m4.m4l4
 
-#define m4_l1  m_u.m_m4.m4l1
-#define m4_l2  m_u.m_m4.m4l2
-#define m4_l3  m_u.m_m4.m4l3
-#define m4_l4  m_u.m_m4.m4l4
+#define m5_c1 m_u.m_m5.m5c1
+#define m5_c2 m_u.m_m5.m5c2
+#define m5_i1 m_u.m_m5.m5i1
+#define m5_i2 m_u.m_m5.m5i2
+#define m5_l1 m_u.m_m5.m5l1
+#define m5_l2 m_u.m_m5.m5l2
+#define m5_l3 m_u.m_m5.m5l3
 
-#define m5_c1  m_u.m_m5.m5c1
-#define m5_c2  m_u.m_m5.m5c2
-#define m5_i1  m_u.m_m5.m5i1
-#define m5_i2  m_u.m_m5.m5i2
-#define m5_l1  m_u.m_m5.m5l1
-#define m5_l2  m_u.m_m5.m5l2
-#define m5_l3  m_u.m_m5.m5l3
-
-#define m6_i1  m_u.m_m6.m6i1
-#define m6_i2  m_u.m_m6.m6i2
-#define m6_i3  m_u.m_m6.m6i3
-#define m6_l1  m_u.m_m6.m6l1
-#define m6_f1  m_u.m_m6.m6f1
+#define m6_i1 m_u.m_m6.m6i1
+#define m6_i2 m_u.m_m6.m6i2
+#define m6_i3 m_u.m_m6.m6i3
+#define m6_l1 m_u.m_m6.m6l1
+#define m6_f1 m_u.m_m6.m6f1
 
 struct mem_map {
-  vir_clicks mem_vir;		/* virtual address */
-  phys_clicks mem_phys;		/* physical address */
-  vir_clicks mem_len;		/* length */
+  vir_clicks mem_vir;   /* virtual address */
+  phys_clicks mem_phys; /* physical address */
+  vir_clicks mem_len;   /* length */
 };
 
-struct copy_info {		/* used by sys_copy(src, dst, bytes) */
-	int cp_src_proc;
-	int cp_src_space;
-	vir_bytes cp_src_vir;
-	int cp_dst_proc;
-	int cp_dst_space;
-	vir_bytes cp_dst_vir;
-	vir_bytes cp_bytes;
+struct copy_info { /* used by sys_copy(src, dst, bytes) */
+  int cp_src_proc;
+  int cp_src_space;
+  vir_bytes cp_src_vir;
+  int cp_dst_proc;
+  int cp_dst_space;
+  vir_bytes cp_dst_vir;
+  vir_bytes cp_bytes;
 };


### PR DESCRIPTION
## Summary
- add `file_pos64` types for 64-bit file positions
- create a compatibility layer for 64-bit file sizes and extents
- extend inode/superblock structures with extent fields and large size
- update filesystem code to use compatibility helpers where needed

## Testing
- `make -C test f=test0` *(fails: No rule to make target '../lib/libc.a')*