### PR TITLE
Refactor fopen to ANSI style

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -1,61 +1,79 @@
 #include "../include/stdio.h"
 
-#define  PMODE    0644
+#define PMODE 0644
 
-
-FILE *fopen(name,mode)
-char *name , *mode;
+/*
+ * Open a file as a stream.
+ *
+ * Supported modes:
+ *      "w" - create/truncate for writing
+ *      "a" - open for appending (create if needed)
+ *      "r" - open for reading
+ */
+FILE *fopen(const char *name, const char *mode)
 {
-	register int i;
-	FILE *fp;
-	char *malloc();
-	int fd,
-	flags = 0;
+    int i;          /* index into _io_table */
+    FILE *fp;       /* resulting stream */
+    char *malloc();
+    int fd;         /* file descriptor from open/creat */
+    int flags = 0;  /* stream flags */
 
-	for (i = 0; _io_table[i] != 0 ; i++) 
-		if ( i >= NFILES )
-			return(NULL);
+    /* Locate a free slot in the open file table. */
+    for (i = 0; _io_table[i] != 0; i++) {
+        if (i >= NFILES)
+            return NULL;
+    }
 
-	switch(*mode){
+    /* Decide how to open or create the file. */
+    switch (*mode) {
+        case 'w':
+            /* Create or truncate the file for writing. */
+            flags |= WRITEMODE;
+            fd = creat(name, PMODE);
+            if (fd < 0)
+                return NULL;
+            break;
 
-	case 'w':
-		flags |= WRITEMODE;
-		if (( fd = creat (name,PMODE)) < 0)
-			return(NULL);
-		break;
+        case 'a':
+            /* Open for appending; create if necessary. */
+            flags |= WRITEMODE;
+            fd = open(name, 1);
+            if (fd < 0)
+                return NULL;
+            lseek(fd, 0L, 2);
+            break;
 
-	case 'a': 
-		flags |= WRITEMODE;
-		if (( fd = open(name,1)) < 0 )
-			return(NULL);
-		lseek(fd,0L,2);
-		break;         
+        case 'r':
+            /* Open an existing file for reading. */
+            flags |= READMODE;
+            fd = open(name, 0);
+            if (fd < 0)
+                return NULL;
+            break;
 
-	case 'r':
-		flags |= READMODE;	
-		if (( fd = open (name,0)) < 0 )
-			return(NULL);
-		break;
-
-	default:
-		return(NULL);
-	}
-
-
-	if (( fp = (FILE *) malloc (sizeof( FILE))) == NULL )
-		return(NULL);
+        default:
+            /* Unrecognized mode. */
+            return NULL;
+    }
 
 
-	fp->_count = 0;
-	fp->_fd = fd;
-	fp->_flags = flags;
-	fp->_buf = malloc( BUFSIZ );
-	if ( fp->_buf == NULL )
-		fp->_flags |=  UNBUFF;
-	else 
-		fp->_flags |= IOMYBUF;
+    /* Allocate the FILE structure. */
+    fp = (FILE *)malloc(sizeof(FILE));
+    if (fp == NULL)
+        return NULL;
 
-	fp->_ptr = fp->_buf;
-	_io_table[i] = fp;
-	return(fp);
+
+    /* Initialize the stream structure. */
+    fp->_count = 0;
+    fp->_fd = fd;
+    fp->_flags = flags;
+    fp->_buf = malloc(BUFSIZ);
+    if (fp->_buf == NULL)
+        fp->_flags |= UNBUFF;    /* fallback to unbuffered if allocation fails */
+    else
+        fp->_flags |= IOMYBUF;
+
+    fp->_ptr = fp->_buf;
+    _io_table[i] = fp;
+    return fp;
 }


### PR DESCRIPTION
## Summary
- modernize `fopen` prototype and parameters
- clarify open/create logic through comments
- use consistent formatting

## Testing
- `cmake -B build`
- `cmake --build build -j$(nproc)` *(fails: conflicting declarations in doprintf.c)*