### PR TITLE
Convert 8088 assembly to portable C

### DIFF
--- a/kernel/klib88.c
+++ b/kernel/klib88.c
@@ -1,0 +1,189 @@
+#include "const.h"
+#include "type.h"
+#include "glo.h"
+#include "proc.h"
+#include <stdint.h>
+
+/*
+ * C translation of the old 8088 assembly helper routines.  These functions
+ * provide basic memory copy, port I/O and miscellaneous helpers needed by
+ * the kernel.  Only minimal inline assembly is used where direct hardware
+ * access is required.
+ */
+
+/* Storage used by lock()/restore(). */
+PUBLIC unsigned lockvar = 0;
+/* Current stack limit for csv().  Not really used in this hosted version. */
+PUBLIC unsigned splimit = 0;
+/* Temporary variable used by vid_copy(). */
+PUBLIC unsigned tmp = 0;
+/* Table for interrupt vectors restored by reboot(). */
+PUBLIC unsigned _vec_table[142];
+
+/*===========================================================================*
+ *                              phys_copy                                    *
+ *===========================================================================*/
+PUBLIC void phys_copy(phys_bytes src, phys_bytes dst, phys_bytes count)
+{
+    /* Copy bytes from one physical location to another using ordinary C. */
+    unsigned char *s = (unsigned char *)(uintptr_t)src;
+    unsigned char *d = (unsigned char *)(uintptr_t)dst;
+    while (count-- > 0)
+        *d++ = *s++;
+}
+
+/*===========================================================================*
+ *                              cp_mess                                      *
+ *===========================================================================*/
+PUBLIC void cp_mess(int src, phys_bytes src_phys, message *src_ptr,
+                    phys_bytes dst_phys, message *dst_ptr)
+{
+    /* Segment parameters are obsolete; just copy the structure. */
+    (void)src_phys;
+    (void)dst_phys;
+
+    dst_ptr->m_source = src;
+    {
+        /* Copy the remaining bytes one by one to avoid structure padding
+         * issues on different compilers.
+         */
+        unsigned char *s = (unsigned char *)&src_ptr->m_type;
+        unsigned char *d = (unsigned char *)&dst_ptr->m_type;
+        size_t bytes = sizeof(message) - sizeof(int);
+        while (bytes-- > 0)
+            *d++ = *s++;
+    }
+}
+
+/*===========================================================================*
+ *                              port I/O                                      *
+ *===========================================================================*/
+PUBLIC void port_out(unsigned port, unsigned value)
+{
+    /* Output one byte to an I/O port. */
+    asm volatile("outb %b0, %w1" : : "a"(value), "Nd"(port));
+}
+
+PUBLIC void port_in(unsigned port, unsigned *value)
+{
+    unsigned char v;
+    asm volatile("inb %w1, %0" : "=a"(v) : "Nd"(port));
+    *value = v;
+}
+
+PUBLIC void portw_out(unsigned port, unsigned value)
+{
+    asm volatile("outw %w0, %w1" : : "a"(value), "Nd"(port));
+}
+
+PUBLIC void portw_in(unsigned port, unsigned *value)
+{
+    unsigned short v;
+    asm volatile("inw %w1, %0" : "=a"(v) : "Nd"(port));
+    *value = v;
+}
+
+/*===========================================================================*
+ *                              lock/unlock/restore                           *
+ *===========================================================================*/
+PUBLIC void lock(void)
+{
+    /* Disable interrupts and remember previous flags. */
+    asm volatile("pushf\n\tcli\n\tpop %0" : "=r"(lockvar) :: "memory");
+}
+
+PUBLIC void unlock(void)
+{
+    /* Re-enable interrupts. */
+    asm volatile("sti");
+}
+
+PUBLIC void restore(void)
+{
+    /* Restore interrupt flag to value saved by lock(). */
+    asm volatile("push %0\n\tpopf" :: "r"(lockvar) : "memory");
+}
+
+/*===========================================================================*
+ *                              build_sig                                    *
+ *===========================================================================*/
+PUBLIC void build_sig(uint16_t *dst, struct proc *rp, int sig)
+{
+    /* Construct the four word stack frame for signal delivery.  Only the
+     * program counter and flags are stored in this portable version.
+     */
+    dst[0] = (uint16_t)sig;
+    dst[1] = (uint16_t)rp->p_pcpsw.rip;    /* low 16 bits of PC */
+    dst[2] = 0;                            /* CS is not used */
+    dst[3] = (uint16_t)rp->p_pcpsw.rflags; /* flags */
+}
+
+/*===========================================================================*
+ *                              csv & cret                                   *
+ *===========================================================================*/
+PUBLIC void csv(unsigned bytes)
+{
+    /* Dummy csv implementation just checks the stack limit. */
+    if (splimit && (unsigned)(&bytes) < splimit)
+        panic("Kernel stack overrun", cur_proc);
+}
+
+PUBLIC void cret(void)
+{
+    /* Nothing to do when returning from a C routine in this version. */
+}
+
+/*===========================================================================*
+ *                              get_chrome                                   *
+ *===========================================================================*/
+PUBLIC int get_chrome(void)
+{
+    /* Ask the BIOS for the equipment list and check bit 0x30. */
+    unsigned char v;
+    asm volatile("int $0x11; movb %%al, %0" : "=r"(v) :: "ax");
+    return (v & 0x30) == 0x30 ? 0 : 1;
+}
+
+/*===========================================================================*
+ *                              vid_copy                                     *
+ *===========================================================================*/
+PUBLIC void vid_copy(uint16_t *buf, unsigned base, unsigned off, unsigned words)
+{
+    /* Copy a sequence of words to video RAM.  The base value selects the
+     * segment of video memory, while off is the starting offset within that
+     * segment.  When buf is NULL the area is filled with blanks.
+     */
+    uint16_t *dst = (uint16_t *)((uintptr_t)base << 4) + off;
+    if (buf == NIL_PTR) {
+        while (words-- > 0)
+            *dst++ = 0x0700;     /* BLANK */
+    } else {
+        while (words-- > 0)
+            *dst++ = *buf++;
+    }
+}
+
+/*===========================================================================*
+ *                              get_byte                                     *
+ *===========================================================================*/
+PUBLIC unsigned char get_byte(unsigned seg, unsigned off)
+{
+    /* Return a byte from an arbitrary segment:offset pair. */
+    uint8_t *p = (uint8_t *)(((uint32_t)seg << 4) + off);
+    return *p;
+}
+
+/*===========================================================================*
+ *                              reboot & wreboot                             *
+ *===========================================================================*/
+PUBLIC void reboot(void)
+{
+    /* BIOS reboot sequence (simplified). */
+    asm volatile("cli; int $0x19" ::: "memory");
+}
+
+PUBLIC void wreboot(void)
+{
+    asm volatile("cli; int $0x16; int $0x19" ::: "memory");
+}
+

--- a/kernel/minix/makefile
+++ b/kernel/minix/makefile
@@ -5,8 +5,8 @@ CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib
 
-obj = mpx88.s main.s proc.s system.s tty.s clock.s memory.s floppy.s wini.s  \
-      printer.s table.s klib88.s dmp.s 
+obj = mpx88.c main.s proc.s system.s tty.s clock.s memory.s floppy.s wini.s  \
+      printer.s table.s klib88.c dmp.s
 
 kernel:	makefile $(obj) $l/libc.a
 	@echo "Start linking Kernel.  /lib/cem will be removed to make space on RAM disk"

--- a/kernel/minix/makefile.at
+++ b/kernel/minix/makefile.at
@@ -2,8 +2,8 @@ CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib
 
-obj = mpx88.s main.s proc.s system.s tty.s clock.s memory.s floppy.s wini.s  \
-      printer.s table.s klib88.s dmp.s 
+obj = mpx88.c main.s proc.s system.s tty.s clock.s memory.s floppy.s wini.s  \
+      printer.s table.s klib88.c dmp.s
 
 kernel:	makefile $(obj) $l/libc.a
 	@echo "Start linking Kernel.  "

--- a/kernel/mpx88.c
+++ b/kernel/mpx88.c
@@ -1,0 +1,123 @@
+#include "const.h"
+#include "type.h"
+#include "glo.h"
+#include "proc.h"
+
+/*
+ * Simplified C replacement for the 8088 assembly scheduler/interrupt logic.
+ * These stubs provide enough structure for building the kernel but do not
+ * perform real context switching.
+ */
+
+extern void sys_call(int function, int caller, int src_dest, message *m_ptr);
+extern void keyboard(void);
+extern void pr_char(void);
+extern void interrupt(int task, message *m_ptr);
+extern void unexpected_int(void);
+extern void trap(void);
+extern void div_trap(void);
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void save(void)
+{
+    /* Real hardware register saving is not performed in this portable C
+     * version.  The function only exists so that higher level code can
+     * compile without change.
+     */
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void restart(void)
+{
+    /* Normally restores a process context and returns from interrupt.  In this
+     * stub nothing is done.
+     */
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void s_call(int function, int src_dest, message *m_ptr)
+{
+    save();
+    sys_call(function, cur_proc, src_dest, m_ptr);
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void tty_int(void)
+{
+    save();
+    keyboard();
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void lpr_int(void)
+{
+    save();
+    pr_char();
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void disk_int(void)
+{
+    message m;
+    save();
+    m.m_type = DISKINT;
+    interrupt(FLOPPY, &m);
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void wini_int(void)
+{
+    message m;
+    save();
+    m.m_type = DISKINT;
+    interrupt(WINI, &m);
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void clock_int(void)
+{
+    message m;
+    save();
+    m.m_type = CLOCK_TICK;
+    interrupt(CLOCK, &m);
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void surprise(void)
+{
+    save();
+    unexpected_int();
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void trp(void)
+{
+    save();
+    trap();
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void divide(void)
+{
+    save();
+    div_trap();
+    restart();
+}
+
+/*---------------------------------------------------------------------------*/
+PUBLIC void idle(void)
+{
+    /* Idle loop executed when no work is available. */
+    for (;;) {
+        asm volatile("hlt");
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace old klib88.s routines with portable C implementation
- add C stub version of mpx88.s
- update legacy kernel makefiles to use new .c sources

## Testing
- `cmake -B build -S .` *(passes)*
- `cmake --build build` *(fails: incompatible declarations in lib sources)*