### PR TITLE
Translate 64-bit assembly to C

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -7,12 +7,9 @@ endif()
 
 set(KERNEL_SRC
     clock.c dmp.c floppy.c main.c memory.c printer.c proc.c system.c
-    table.c tty.c idt64.c ${WINI_SRC})
+    table.c tty.c idt64.c mpx64.c klib64.c syscall.c ${WINI_SRC})
 
-set(KERNEL_ASM
-    mpx64.s
-    klib64.s
-    syscall.s)
+set(KERNEL_ASM)
 
 add_executable(kernel ${KERNEL_SRC} ${KERNEL_ASM})
 

--- a/kernel/klib64.c
+++ b/kernel/klib64.c
@@ -1,0 +1,135 @@
+#include "const.h"
+#include "type.h"
+#include "glo.h"
+#include "proc.h"
+#include <stdint.h>
+
+/* Minimal 64-bit implementations of low level kernel routines. */
+
+/* Copy a block of physical memory. */
+void phys_copy(void *src, void *dst, long bytes)
+{
+    asm volatile(
+        "rep movsb"
+        : "=S"(src), "=D"(dst), "=c"(bytes)
+        : "0"(src), "1"(dst), "2"(bytes)
+        : "memory");
+}
+
+/* Copy a message from one buffer to another. */
+void cp_mess(int src, void *src_click, void *src_off,
+             void *dst_click, void *dst_off)
+{
+    (void)src_click;
+    (void)dst_click;
+    int *d = dst_off;
+    const int *s = src_off;
+    d[0] = src;
+    asm volatile(
+        "lea 4(%[dst]), %%rdi\n\t"
+        "lea 4(%[src]), %%rsi\n\t"
+        "mov %[count], %%rcx\n\t"
+        "rep movsb"
+        :
+        : [dst] "r"(d), [src] "r"(s), [count] "i"(MESS_SIZE - 4)
+        : "rdi", "rsi", "rcx", "memory");
+}
+
+/* Output a byte to a port. */
+void port_out(unsigned port, unsigned val)
+{
+    asm volatile("outb %b0, (%w1)" : : "a"(val), "d"(port));
+}
+
+/* Input a byte from a port. */
+void port_in(unsigned port, unsigned *val)
+{
+    unsigned char tmp;
+    asm volatile("inb (%w1), %b0" : "=a"(tmp) : "d"(port));
+    *val = tmp;
+}
+
+/* Output a word to a port. */
+void portw_out(unsigned port, unsigned val)
+{
+    asm volatile("outw %w0, (%w1)" : : "a"(val), "d"(port));
+}
+
+/* Input a word from a port. */
+void portw_in(unsigned port, unsigned *val)
+{
+    unsigned short tmp;
+    asm volatile("inw (%w1), %w0" : "=a"(tmp) : "d"(port));
+    *val = tmp;
+}
+
+/* Disable interrupts and save flags. */
+static uint64_t lockvar;
+void lock(void)
+{
+    asm volatile("pushfq\n\tcli\n\tpop %0" : "=m"(lockvar) :: "memory");
+}
+
+/* Enable interrupts. */
+void unlock(void)
+{
+    asm volatile("sti");
+}
+
+/* Restore saved interrupt flags. */
+void restore(void)
+{
+    asm volatile("push %0\n\tpopfq" : : "m"(lockvar) : "memory");
+}
+
+/* Build a signal frame. */
+void build_sig(struct sig_info *dst, struct proc *rp, int sig)
+{
+    dst->signo = sig;
+    dst->sigpcpsw.rip = rp->p_pcpsw.rip;
+    dst->sigpcpsw.rflags = rp->p_pcpsw.rflags;
+}
+
+/* Get display type (stub returns 0). */
+int get_chrome(void)
+{
+    return 0;
+}
+
+/* Copy words to video memory. */
+void vid_copy(void *buf, unsigned base, unsigned off, unsigned words)
+{
+    if (!buf)
+        return;
+    uint16_t *dst = (uint16_t *)(uintptr_t)(base + off);
+    uint16_t *src = buf;
+    asm volatile(
+        "rep movsw"
+        : "=S"(src), "=D"(dst), "=c"(words)
+        : "0"(src), "1"(dst), "2"(words)
+        : "memory");
+}
+
+/* Fetch a byte from memory. */
+unsigned char get_byte(unsigned seg, unsigned off)
+{
+    unsigned char *p = (unsigned char *)(uintptr_t)off;
+    (void)seg;
+    return *p;
+}
+
+/* Halt the CPU. */
+void reboot(void)
+{
+    asm volatile("hlt");
+}
+
+/* Halt the CPU (warm reboot placeholder). */
+void wreboot(void)
+{
+    asm volatile("hlt");
+}
+
+/* Placeholders for assembly variables from original code. */
+uint64_t splimit;
+

--- a/kernel/mpx64.c
+++ b/kernel/mpx64.c
@@ -1,0 +1,218 @@
+#include "const.h"
+#include "type.h"
+#include "glo.h"
+#include "proc.h"
+#include <stdint.h>
+
+/* 64-bit context switch and interrupt entry code translated from assembly. */
+
+#define RAX_OFF   0
+#define RBX_OFF   8
+#define RCX_OFF  16
+#define RDX_OFF  24
+#define RSI_OFF  32
+#define RDI_OFF  40
+#define RBP_OFF  48
+#define R8_OFF   56
+#define R9_OFF   64
+#define R10_OFF  72
+#define R11_OFF  80
+#define R12_OFF  88
+#define R13_OFF  96
+#define R14_OFF 104
+#define R15_OFF 112
+#define SP_OFF  120
+#define PC_OFF  128
+#define PSW_OFF 136
+
+extern char k_stack[K_STACK_BYTES];
+
+/* Save registers to current process structure and switch to kernel stack. */
+void save(void) __attribute__((naked));
+void save(void)
+{
+    __asm__ volatile(
+        "push %rax\n\t"
+        "push %rbx\n\t"
+        "push %rcx\n\t"
+        "push %rdx\n\t"
+        "push %rsi\n\t"
+        "push %rdi\n\t"
+        "push %rbp\n\t"
+        "push %r8\n\t"
+        "push %r9\n\t"
+        "push %r10\n\t"
+        "push %r11\n\t"
+        "push %r12\n\t"
+        "push %r13\n\t"
+        "push %r14\n\t"
+        "push %r15\n\t"
+        "movq _proc_ptr(%%rip), %%r15\n\t"
+        "movq 120(%%rsp), %%rax\n\t"
+        "movq %%rax, %c0(%%r15)\n\t"
+        "movq 136(%%rsp), %%rax\n\t"
+        "movq %%rax, %c1(%%r15)\n\t"
+        "lea 120(%%rsp), %%rax\n\t"
+        "movq %%rax, %c2(%%r15)\n\t"
+        "movq 112(%%rsp), %%rax\n\t"
+        "movq %%rax, %c3(%%r15)\n\t"
+        "movq 104(%%rsp), %%rax\n\t"
+        "movq %%rax, %c4(%%r15)\n\t"
+        "movq 96(%%rsp), %%rax\n\t"
+        "movq %%rax, %c5(%%r15)\n\t"
+        "movq 88(%%rsp), %%rax\n\t"
+        "movq %%rax, %c6(%%r15)\n\t"
+        "movq 80(%%rsp), %%rax\n\t"
+        "movq %%rax, %c7(%%r15)\n\t"
+        "movq 72(%%rsp), %%rax\n\t"
+        "movq %%rax, %c8(%%r15)\n\t"
+        "movq 64(%%rsp), %%rax\n\t"
+        "movq %%rax, %c9(%%r15)\n\t"
+        "movq 56(%%rsp), %%rax\n\t"
+        "movq %%rax, %c10(%%r15)\n\t"
+        "movq 48(%%rsp), %%rax\n\t"
+        "movq %%rax, %c11(%%r15)\n\t"
+        "movq 40(%%rsp), %%rax\n\t"
+        "movq %%rax, %c12(%%r15)\n\t"
+        "movq 32(%%rsp), %%rax\n\t"
+        "movq %%rax, %c13(%%r15)\n\t"
+        "movq 24(%%rsp), %%rax\n\t"
+        "movq %%rax, %c14(%%r15)\n\t"
+        "movq 16(%%rsp), %%rax\n\t"
+        "movq %%rax, %c15(%%r15)\n\t"
+        "movq 8(%%rsp), %%rax\n\t"
+        "movq %%rax, %c16(%%r15)\n\t"
+        "movq (%%rsp), %%rax\n\t"
+        "movq %%rax, %c17(%%r15)\n\t"
+        "lea k_stack+K_STACK_BYTES(%%rip), %%rsp\n\t"
+        "ret"
+        :
+        : "i"(PC_OFF), "i"(PSW_OFF), "i"(SP_OFF),
+          "i"(RAX_OFF), "i"(RBX_OFF), "i"(RCX_OFF), "i"(RDX_OFF),
+          "i"(RSI_OFF), "i"(RDI_OFF), "i"(RBP_OFF), "i"(R8_OFF),
+          "i"(R9_OFF), "i"(R10_OFF), "i"(R11_OFF), "i"(R12_OFF),
+          "i"(R13_OFF), "i"(R14_OFF), "i"(R15_OFF)
+        : "memory", "rax", "r15");
+}
+
+/* Restore registers and continue the interrupted task. */
+void restart(void) __attribute__((naked));
+void restart(void)
+{
+    __asm__ volatile(
+        "movq _proc_ptr(%%rip), %%r15\n\t"
+        "movq %c0(%%r15), %%rsp\n\t"
+        "movq %c1(%%r15), %%r15\n\t"
+        "movq %c2(%%r15), %%r14\n\t"
+        "movq %c3(%%r15), %%r13\n\t"
+        "movq %c4(%%r15), %%r12\n\t"
+        "movq %c5(%%r15), %%r11\n\t"
+        "movq %c6(%%r15), %%r10\n\t"
+        "movq %c7(%%r15), %%r9\n\t"
+        "movq %c8(%%r15), %%r8\n\t"
+        "movq %c9(%%r15), %%rbp\n\t"
+        "movq %c10(%%r15), %%rdi\n\t"
+        "movq %c11(%%r15), %%rsi\n\t"
+        "movq %c12(%%r15), %%rdx\n\t"
+        "movq %c13(%%r15), %%rcx\n\t"
+        "movq %c14(%%r15), %%rbx\n\t"
+        "movq %c15(%%r15), %%rax\n\t"
+        "pushq %c16(%%r15)\n\t"
+        "pushq %c17(%%r15)\n\t"
+        "iretq"
+        :
+        : "i"(SP_OFF), "i"(R15_OFF), "i"(R14_OFF), "i"(R13_OFF),
+          "i"(R12_OFF), "i"(R11_OFF), "i"(R10_OFF), "i"(R9_OFF),
+          "i"(R8_OFF), "i"(RBP_OFF), "i"(RDI_OFF), "i"(RSI_OFF),
+          "i"(RDX_OFF), "i"(RCX_OFF), "i"(RBX_OFF), "i"(RAX_OFF),
+          "i"(PSW_OFF), "i"(PC_OFF)
+        : "memory", "rax", "r15");
+}
+
+/* Simple interrupt service routines. */
+void isr_default(void) __attribute__((naked));
+void isr_default(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "call _surprise\n\t"
+        "jmp restart"
+    );
+}
+
+void isr_clock(void) __attribute__((naked));
+void isr_clock(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "call _clock_int\n\t"
+        "jmp restart"
+    );
+}
+
+void isr_keyboard(void) __attribute__((naked));
+void isr_keyboard(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "call _tty_int\n\t"
+        "jmp restart"
+    );
+}
+
+void s_call(void) __attribute__((naked));
+void s_call(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "movq _proc_ptr(%%rip), %%rdi\n\t"
+        "movq 16(%%rdi), %%rsi\n\t"
+        "movq (%%rdi), %%rdx\n\t"
+        "movq $0, %%rcx\n\t"
+        "call _sys_call\n\t"
+        "jmp restart"
+    );
+}
+
+void lpr_int(void) __attribute__((naked));
+void lpr_int(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "call _pr_char\n\t"
+        "jmp restart"
+    );
+}
+
+void disk_int(void) __attribute__((naked));
+void disk_int(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "movq _int_mess+2(%%rip), %%rax\n\t"
+        "movq %%rax, %%rdi\n\t"
+        "call _interrupt\n\t"
+        "jmp restart"
+    );
+}
+
+void divide(void) __attribute__((naked));
+void divide(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "call _div_trap\n\t"
+        "jmp restart"
+    );
+}
+
+void trp(void) __attribute__((naked));
+void trp(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "call _trap\n\t"
+        "jmp restart"
+    );
+}
+

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -1,0 +1,50 @@
+#include "const.h"
+#include "type.h"
+#include "glo.h"
+#include "proc.h"
+#include <stdint.h>
+
+#ifdef __x86_64__
+
+/* Configure system call Model Specific Registers. */
+void init_syscall_msrs(void)
+{
+    asm volatile(
+        "mov $0xC0000080, %%ecx\n\t"
+        "rdmsr\n\t"
+        "or $1, %%eax\n\t"
+        "wrmsr\n\t"
+        "mov $0xC0000081, %%ecx\n\t"
+        "mov $(0x18 << 16) | 0x18, %%eax\n\t"
+        "xor %%edx, %%edx\n\t"
+        "wrmsr\n\t"
+        "mov $0xC0000082, %%ecx\n\t"
+        "mov $syscall_entry, %%rax\n\t"
+        "wrmsr\n\t"
+        "mov $0xC0000084, %%ecx\n\t"
+        "xor %%eax, %%eax\n\t"
+        "xor %%edx, %%edx\n\t"
+        "wrmsr"
+        :
+        :
+        : "eax", "ecx", "edx", "memory");
+}
+
+/* Entry point for user mode syscalls. */
+void syscall_entry(void) __attribute__((naked));
+void syscall_entry(void)
+{
+    __asm__ volatile(
+        "call save\n\t"
+        "mov %rdi, %rax\n\t"
+        "mov %rdx, %rdi\n\t"
+        "mov _cur_proc(%%rip), %esi\n\t"
+        "mov %rax, %rdx\n\t"
+        "mov %rsi, %rcx\n\t"
+        "call _sys_call\n\t"
+        "jmp restart"
+    );
+}
+
+#endif
+


### PR DESCRIPTION
## Summary
- translate klib64.s assembly routines to C with inline asm
- convert mpx64.s context switch and interrupt logic to C
- move syscall MSR setup and entry code to syscall.c
- update kernel build list to use new C files instead of assembly

## Testing
- `cmake -S . -B build`
- `cmake --build build --target kernel` *(fails: error building dependency minixlib)*