### PR TITLE
Remove assembly sources from lib builds

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,9 +1,3 @@
 file(GLOB LIB_SRC CONFIGURE_DEPENDS *.c minix/*.c)
-set(LIB_ASM
-    catchsig.s
-    csv.s
-    getutil.s
-    sendrec.s
-    setjmp.s
-    minix/setjmp.s)
-add_library(minixlib STATIC ${LIB_SRC} ${LIB_ASM})
+# Build the library solely from C sources.
+add_library(minixlib STATIC ${LIB_SRC})

--- a/lib/doprintf.c
+++ b/lib/doprintf.c
@@ -1,5 +1,10 @@
 #include "../include/stdio.h"
 
+/* Forward declarations for helper routines. */
+static void _bintoascii(long num, int radix, char *a);
+static void _printit(char *str, int w1, int w2, char padchar, int length,
+                     FILE *file);
+
 #define MAXDIGITS 12
 #define PRIVATE   static
 
@@ -116,10 +121,8 @@ int args;
 
 
 
-PRIVATE _bintoascii (num, radix, a)
-long    num;
-int     radix;
-char    *a;
+/* Convert a number to an ASCII string in the given radix. */
+static void _bintoascii(long num, int radix, char *a)
 {
 	char b[MAXDIGITS];
 	int hit, negative;
@@ -182,12 +185,9 @@ char    *a;
 }
 
 
-PRIVATE _printit(str, w1, w2, padchar, length, file)
-char *str;
-int w1, w2;
-char padchar;
-int length;
-FILE *file;
+/* Output a formatted string with padding control. */
+static void _printit(char *str, int w1, int w2, char padchar, int length,
+                     FILE *file)
 {
 	int len2 = length;
 	int temp;

--- a/lib/makefile
+++ b/lib/makefile
@@ -1,16 +1,11 @@
 CC ?= cc
-AS ?= nasm
 AR ?= ar
 CFLAGS ?= -O2
-ASMFLAGS ?= -f elf64
-OBJS := $(patsubst %.c,%.o,$(wildcard *.c)) \
-         $(patsubst %.s,%.o,$(wildcard *.s))
+# Object files derived only from C sources.
+OBJS := $(patsubst %.c,%.o,$(wildcard *.c))
 
 lib.a: $(OBJS)
 	$(AR) rcs $@ $(OBJS)
-
-%.o: %.s
-	$(AS) $(ASMFLAGS) -o $@ $<
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
## Summary
- drop unused NASM build rules in `lib/makefile`
- remove assembly file list from `lib/CMakeLists.txt`
- modernize `doprintf.c` helper declarations

## Testing
- `make -C lib` *(fails: struct passwd issues)*
- `cmake -B build -S .`
- `cmake --build build` *(fails: struct passwd issues)*