### PR TITLE
Fix makefile to compile C sources

### DIFF
--- a/tools/makefile
+++ b/tools/makefile
@@ -1,7 +1,5 @@
 l=../lib
 CFLAGS = -O -DPCIX
-ASM ?= nasm
-ASMFLAGS ?= -f elf64
 
 all:
 	make init
@@ -26,8 +24,10 @@ init:	$l/libc.a init.o $l/head.o
 # an object (.o) file; others make an a.out file directly. If your boot 
 # diskette does not start out by printing 'Booting MINIX 1.0' the problem is
 # probably that you have not made a good boot block.
-bootblok:	bootblok.s
-	nasm -f bin -o bootblok bootblok.s
+bootblok:	bootblok.c
+	cc $(CFLAGS) -o bootblokgen bootblok.c
+	./bootblokgen
+	rm -f bootblokgen
 	@echo bootblok done.
 
 build:	build.o
@@ -43,10 +43,10 @@ mkfs.o:	mkfs.c
 fsck:	fsck.o fsck1.o diskio.o
 	ld -o fsck  fsck1.o fsck.o diskio.o $l/libc.a
 	@echo fsck done.
-fsck1.o:	fsck1.s
-	$(ASM) $(ASMFLAGS) -o fsck1.o fsck1.s
-diskio.o:	diskio.s
-	$(ASM) $(ASMFLAGS) -o diskio.o diskio.s
+fsck1.o:	fsck1.c
+	cc $(CFLAGS) -c fsck1.c
+diskio.o:	diskio.c
+	cc $(CFLAGS) -c diskio.c
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces
 # appears in the image file just as the original does on the disk, except that


### PR DESCRIPTION
## Summary
- drop NASM references from tools makefile
- build `bootblok` from C source via helper executable
- compile `fsck1.c` and `diskio.c` instead of missing assembly files

## Testing
- `make -C tools diskio.o`
- `make -C tools fsck1.o` *(fails: conflicting types for built-ins)*
- `make -C tools bootblok` *(fails: Text file busy, fixed by separate generator)*