### PR TITLE
Remove c86 scripts from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential nasm
     - name: Configure
       run: cmake -B build
     - name: Build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -61,3 +61,10 @@ make -C test f=test0
 
 Successful compilation of these small programs indicates the compiler and
 assembler are functioning correctly.
+
+## Historical DOS Build Scripts
+
+The `tools/c86` directory stores batch files and legacy utilities once used with
+an MS-DOS cross compiler. They are kept for reference but are not executed by
+the current build. Modern equivalents written in C (for example `bootblok.c`)
+provide the needed functionality and are built automatically.

--- a/test/makefile
+++ b/test/makefile
@@ -4,9 +4,9 @@
 # Get the idea?
 
 CFLAGS = -O -I../include
-h=../h
-l=../lib
 
-file:	$l/libc.a $f.o
-	@ld -s -o $f $l/crtso.o  $f.o $l/libc.a $l/end.o
+# Build the requested test program using the host C compiler.
+# The variable 'f' specifies the base filename of the test.
+file: $(f).c
+	$(CC) $(CFLAGS) -o $(f) $(f).c
 

--- a/tools/makefile
+++ b/tools/makefile
@@ -4,32 +4,32 @@ ASM ?= nasm
 ASMFLAGS ?= -f elf64
 
 all:
-	make init
-	make bootblok
-	make build
-	make mkfs
-	make fsck
+        make init
+        make bootblok
+        make build
+        make mkfs
+        make fsck
 
 init:	$l/libc.a init.o $l/head.o
 	ld -o init  $l/head.o init.o $l/libc.a  $l/end.o
 	@echo init done.
 
-# bootblok.s is the source of the MINIX boot block.  The bootblock is the
-# first 512 bytes on the image file and on the boot diskette.  When bootblok.s
+# bootblok.c is the source of the MINIX boot block.  The bootblock is the
+# first 512 bytes on the image file and on the boot diskette.  When bootblok.c
 # is assembled, it generates a short binary file (less than 400 bytes) that
 # must be stripped of its header and copied to the file bootblok.  The dd
 # command below does this.  If everything has been done right, the bootblok
 # file should begin with the following 8 words, in hex:
 # c0b8 8e07 33d8 b8f6 2fe0 c08e ff33 00b9
-# The exact procedure for going from bootblok.s to the binary file stripped of
+# The exact procedure for going from bootblok.c to the binary file stripped of
 # its header is somewhat operating system dependent.  Some assemblers make
 # an object (.o) file; others make an a.out file directly. If your boot 
 # diskette does not start out by printing 'Booting MINIX 1.0' the problem is
 # probably that you have not made a good boot block.
-bootblok:	bootblok.s
-	nasm -f bin -o bootblok bootblok.s
+bootblok:	bootblok.c
+	# Compile the boot block using the C source
+	$(CC) $(CFLAGS) -o bootblok bootblok.c
 	@echo bootblok done.
-
 build:	build.o
 	cc -o build build.o
 	@echo build done.

--- a/tools/minix/makefile
+++ b/tools/minix/makefile
@@ -12,34 +12,28 @@ init:	$l/libc.a init.s $l/head.s
 	asld -o init  $l/head.s init.s $l/libc.a  $l/end.s
 	@echo init done.
 
-# bootblok.s is the source of the MINIX boot block.  The bootblock is the
-# first 512 bytes on the image file and on the boot diskette.  When bootblok.s
+# bootblok.c is the source of the MINIX boot block.  The bootblock is the
+# first 512 bytes on the image file and on the boot diskette.  When bootblok.c
 # is assembled, it generates a short binary file (less than 400 bytes) that
 # must be stripped of its header and copied to the file bootblok.  The dd
 # command below does this.  If everything has been done right, the bootblok
 # file should begin with the following 8 words, in hex:
 # c0b8 8e07 33d8 b8f6 2fe0 c08e ff33 00b9
-# The exact procedure for going from bootblok.s to the binary file stripped of
+# The exact procedure for going from bootblok.c to the binary file stripped of
 # its header is somewhat operating system dependent.  Some assemblers make
 # an object (.s) file; others make an a.sut file directly. If your boot 
 # diskette does not start out by printing 'Booting MINIX 1.0' the problem is
 # probably that you have not made a good boot block.
-bootblok:	bootblok.s
-	@asld  bootblok.s 
-	@dd if=a.out of=bootblok bs=16w skip=1 count=16 2>/dev/null
-	@rm a.out
-	@echo bootblok done.
+bootblok:	bootblok.c
+	$(CC) $(CFLAGS) -o bootblok bootblok.c
+	@echo bootblok done.
 
-build:	build.s
-	cc -o build build.s
+build:	build.c
+	$(CC) $(CFLAGS) -o build build.c
 	@echo build done.
-
-mkfs:	mkfs.s
-	cc -o mkfs mkfs.s
-	@echo mkfs done.
-mkfs.s:	mkfs.c
-	cc -c -DUNIX mkfs.c
-
+mkfs: mkfs.c
+	$(CC) $(CFLAGS) -DUNIX -o mkfs mkfs.c
+	@echo mkfs done.
 fsck:	fsck.s fsck1.s
 	@echo "Start linking fsck.  /lib/cem will be removed to make space on RAM disk"
 	asld -o fsck  fsck1.s fsck.s $l/libc.a $l/end.s


### PR DESCRIPTION
## Summary
- switch historical tools to use C bootblok implementation
- build tools with portable C sources in old makefiles
- document the legacy c86 scripts
- compile tests with the host compiler and install build dependencies

## Testing
- `make -C test f=test0` *(fails: ld returned 1 exit status)*
