### PR TITLE
Default build uses clang

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,9 +5,10 @@ build environment works on a Unix-like host.
 
 ## Prerequisites
 
-A 64-bit x86 compiler toolchain is required.  GCC 9 or later and either NASM
-2.14 or YASM 1.3 are known to work.  CMake 3.5 or newer is needed when using the
-CMake build system.
+A 64-bit x86 compiler toolchain is required.  Clang is used by default across
+all makefiles and CMake scripts.  GCC 9 or later can still be used if desired,
+and either NASM 2.14 or YASM 1.3 are known to work.  CMake 3.5 or newer is
+needed when using the CMake build system.
 
 ## Building with Makefiles
 
@@ -36,12 +37,15 @@ You can select the AT or PC/XT wini driver using the options described in the
 
 The build can target a bare x86\_64 system using a cross toolchain.  Specify the
 tool prefix through the `CROSS_PREFIX` variable.  When invoking CMake directly
-pass `-DCROSS_COMPILE_X86_64=ON` along with the prefix:
+pass `-DCROSS_COMPILE_X86_64=ON` along with the prefix.  Clang will be invoked
+with that prefix for cross compiling:
 
 ```sh
 cmake -B build -DCROSS_COMPILE_X86_64=ON -DCROSS_PREFIX=x86_64-elf-
 cmake --build build
 ```
+
+These commands will call `${CROSS_PREFIX}clang` for compilation.
 
 The top-level `Makefile` accepts the same variable so the above commands can be
 simplified to:
@@ -49,6 +53,8 @@ simplified to:
 ```sh
 make CROSS_PREFIX=x86_64-elf-
 ```
+
+The makefile passes the prefix to clang automatically.
 
 ## Testing the Build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(minix1 C)
 
+# Default to clang when no explicit compiler is configured
+if(NOT CMAKE_C_COMPILER)
+  set(CMAKE_C_COMPILER clang)
+endif()
+
 # Enforce a strict C90 environment across the project
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -17,7 +22,8 @@ if(CROSS_COMPILE_X86_64)
   endif()
   set(CMAKE_SYSTEM_NAME Generic)
   set(CMAKE_SYSTEM_PROCESSOR x86_64)
-  set(CMAKE_C_COMPILER "${CROSS_PREFIX}gcc")
+  # Use clang for cross compilation as well
+  set(CMAKE_C_COMPILER "${CROSS_PREFIX}clang")
   set(CMAKE_AR "${CROSS_PREFIX}ar")
   set(CMAKE_RANLIB "${CROSS_PREFIX}ranlib")
   set(CMAKE_LINKER "${CROSS_PREFIX}ld")

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-CMAKE_FLAGS :=
+# Use clang as the default C compiler for all builds
+CC ?= clang
+
+# Pass the selected compiler to CMake
+CMAKE_FLAGS := -DCMAKE_C_COMPILER=$(CC)
 ifdef DRIVER_AT
 CMAKE_FLAGS += -DDRIVER_AT=$(DRIVER_AT)
 endif

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ release.
 
 ## Build Requirements
 
-Building now requires a 64-bit x86 compiler toolchain.  Recent versions of GCC
-(9 or later) together with NASM 2.14 or YASM 1.3 work well for compiling the C
-and assembly sources.  Older 16-bit configurations are no longer supported.
+Building now requires a 64-bit x86 compiler toolchain.  Clang is the default
+compiler throughout the repository.  Recent versions of GCC (9 or later) also
+work, but every build file now selects clang unless explicitly overridden.
+NASM 2.14 or YASM 1.3 remain the recommended assemblers.  Older 16-bit
+configurations are no longer supported.
 
 More details on building and verifying the project are available in
 `BUILDING.md`.

--- a/commands/makefile
+++ b/commands/makefile
@@ -5,10 +5,13 @@
 
 l=/usr/lib
 i=/usr/include
+# Use clang to compile commands
+CC ?= clang
+ 
 CFLAGS=  -I/usr/include -F
 
 file:	$l/libc.a $f.s
-	@cc -o bin/$f $f.s
+	@$(CC) -o bin/$f $f.s
 	@chmem =2048 bin/$f >/dev/null
 	@echo "$f done ."
 

--- a/fs/minix/makefile
+++ b/fs/minix/makefile
@@ -1,3 +1,5 @@
+# Use clang for the 16-bit fs build
+CC ?= clang
 CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -1,6 +1,8 @@
 # The kernel directory contains PC/XT and AT wini driver sources.  Set the
 # `WINI_DRIVER` variable to `pc` or `at` when invoking `make` to select the
 # correct driver.  If not specified the PC/XT driver is used.
+# Use clang to compile the kernel
+CC ?= clang
 CFLAGS = -O
 h=../h
 l=../lib

--- a/kernel/minix/makefile
+++ b/kernel/minix/makefile
@@ -1,6 +1,8 @@
 # The kernel directory contains files xt_wini.c and at_wini.c.  Before running
 # make you must copy one of these to wini.c, depending on whether you have a
 # PC or an AT.  You must do this even if you do not have a hard disk..
+# Use clang for the 16-bit kernel build
+CC ?= clang
 CFLAGS= -w -F -T.
 h=../h
 l=/usr/lib

--- a/lib/makefile
+++ b/lib/makefile
@@ -1,4 +1,5 @@
-CC ?= cc
+# Default to clang for building the library
+CC ?= clang
 AR ?= ar
 CFLAGS ?= -O2
 # Object files derived only from C sources.

--- a/mm/makefile
+++ b/mm/makefile
@@ -1,3 +1,5 @@
+# Use clang to compile mm
+CC ?= clang
 CFLAGS= -O
 h=../h
 l=../lib

--- a/mm/minix/makefile
+++ b/mm/minix/makefile
@@ -1,3 +1,5 @@
+# Use clang for the 16-bit mm build
+CC ?= clang
 CFLAGS = -w -F -T.
 h=../h
 l=/usr/lib

--- a/test/makefile
+++ b/test/makefile
@@ -3,6 +3,8 @@
 # To make  'test2', type:   make f=test2
 # Get the idea?
 
+# Use clang for building the test programs
+CC ?= clang
 CFLAGS = -O -I../include
 
 # Build the requested test program using the host C compiler.

--- a/test/minix/makefile
+++ b/test/minix/makefile
@@ -2,6 +2,8 @@
 # To make  'test1', type:   make f=test1
 # To make  'test2', type:   make f=test2
 # Get the idea?
+# Use clang for the 16-bit tests
+CC ?= clang
 
 l=/usr/lib
 

--- a/tools/makefile
+++ b/tools/makefile
@@ -1,3 +1,5 @@
+# Use clang to build the tooling
+CC ?= clang
 l=../lib
 CFLAGS = -O -DPCIX
 
@@ -30,22 +32,22 @@ bootblok:	bootblok.c
 	$(CC) $(CFLAGS) -o bootblokgen bootblok.c
 	@echo bootblok done.
 build:	build.o
-	cc -o build build.o
+	$(CC) -o build build.o
 	@echo build done.
 
 mkfs:	mkfs.o
-	cc -o mkfs mkfs.o
+	$(CC) -o mkfs mkfs.o
 	@echo mkfs done.
 mkfs.o:	mkfs.c
-	cc -c -O -DUNIX mkfs.c
+	$(CC) -c -O -DUNIX mkfs.c
 
 fsck:	fsck.o fsck1.o diskio.o
 	ld -o fsck  fsck1.o fsck.o diskio.o $l/libc.a
 	@echo fsck done.
 fsck1.o:	fsck1.c
-	cc $(CFLAGS) -c fsck1.c
+	$(CC) $(CFLAGS) -c fsck1.c
 diskio.o:	diskio.c
-	cc $(CFLAGS) -c diskio.c
+	$(CC) $(CFLAGS) -c diskio.c
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces
 # appears in the image file just as the original does on the disk, except that

--- a/tools/minix/makefile
+++ b/tools/minix/makefile
@@ -1,3 +1,5 @@
+# Use clang for the legacy tooling
+CC ?= clang
 l=/usr/lib
 CFLAGS = -F
 
@@ -39,8 +41,8 @@ fsck:	fsck.s fsck1.s
 	asld -o fsck  fsck1.s fsck.s $l/libc.a $l/end.s
 	@echo fsck done. Please restore /lib/cem manually.
 fsck.s: fsck.c
-	cc -c -w -F -T. fsck.c
-
+	$(CC) -c -w -F -T. fsck.c
+	
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces
 # appears in the image file just as the original does on the disk, except that


### PR DESCRIPTION
## Summary
- use clang as the compiler in every makefile
- default CMake compiler is clang
- document clang requirement in README and BUILDING docs

## Testing
- `make clean`
- `make` *(fails: `/workspace/minix1/lib/getpwent.c:78:13: error: ‘struct passwd’ has no member named ‘name’`)*
- `make -C test f=test0` *(fails: `/usr/bin/ld: errno: TLS definition in /lib/x86_64-linux-gnu/libc.so.6 section .tbss mismatches non-TLS reference`)*