### PR TITLE
Add clang-format and clang-tidy configs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+TabWidth: 4
+UseTab: Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: '-*,bugprone-*,portability-*'
+WarningsAsErrors: '*'
+FormatStyle: file
+HeaderFilterRegex: '.*'

--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ The file `TREE.txt` records the directory layout of the repository. To refresh
 it run `python3 tools/ascii_tree.py --exclude TREE.txt > TREE.txt` from the
 project root.
 
+
+## Code Style
+
+All C sources adhere to a consistent formatting defined in `.clang-format`.  The
+repository follows the LLVM style with four space indentation.  Static analysis
+is configured via `.clang-tidy` enabling the `bugprone-*` and `portability-*`
+check groups and treating all warnings as errors.


### PR DESCRIPTION
## Summary
- add `.clang-format` with LLVM style and four-space indents
- enable `bugprone-*` and `portability-*` checks via `.clang-tidy`
- document formatting rules in README

## Testing
- `make clean`
- `make` *(fails: conflicting types in setjmp.c)*