### PR TITLE
Add clang tooling workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,22 @@ jobs:
           make -C test f=$t
           ./test/$t
         done
+
+  clang-tools:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install clang tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang clang-tidy clang-format cmake build-essential
+    - name: Generate compile commands
+      run: cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Check formatting
+      run: |
+        FILES=$(git ls-files '*.c' '*.h')
+        clang-format --dry-run --Werror $FILES
+    - name: Run clang-tidy
+      run: |
+        FILES=$(git ls-files '*.c')
+        clang-tidy -p build -warnings-as-errors='*' $FILES


### PR DESCRIPTION
## Summary
- run clang-format on all .c and .h files
- run clang-tidy using the generated compile database
- ensure the workflow fails if formatting or tidy issues exist

## Testing
- `clang-format --version`
- `clang-tidy --version`
