### PR TITLE
Use relative build paths and overridable flags

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,6 +21,11 @@ cd lib
 make
 ```
 
+The makefiles use relative paths to locate headers and the C library.
+Headers are taken from `../include` and the library defaults to
+`../lib/lib.a`.  Override `CC`, `CFLAGS`, or `LDFLAGS` on the command
+line to adjust the build.
+
 ## Building with CMake
 
 A more convenient option is to use CMake from the repository root:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ The boot utilities now include a rewritten `bootblok.s` capable of loading a 64-
 Every directory contains a `makefile` for building that part of the system.
 Running `make` inside a component (for example `kernel` or `lib`) produces the
 corresponding binaries or libraries.  The `test` directory also provides
-makefiles for compiling small test programs.
+makefiles for compiling small test programs.  All component makefiles search
+for headers under `../include` and link against `../lib/lib.a` by default.
+You can override the `CC`, `CFLAGS`, or `LDFLAGS` variables on the command
+line to customize the build, for example:
+
+```sh
+make -C kernel CC=gcc CFLAGS='-g'
+```
 
 Alternatively the sources can be built with CMake.  From the repository root
 run:

--- a/commands/makefile
+++ b/commands/makefile
@@ -3,22 +3,25 @@
 # To make  'cat', type:   make f=cat
 # Get the idea?
 
-l=/usr/lib
-i=/usr/include
+l=../lib
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
 # Use clang to compile commands
 CC ?= clang
  
-CFLAGS=  -I/usr/include -F
+CFLAGS ?= -F
+CFLAGS += -I$(INC)
 
-file:	$l/libc.a $f.s
-	@$(CC) -o bin/$f $f.s
+file:	$(LIB) $(f).s
+	@$(CC) $(CFLAGS) $(LDFLAGS) -o bin/$f $f.s $(LIB)
 	@chmem =2048 bin/$f >/dev/null
 	@echo "$f done ."
 
-mined:	mined1.s mined2.s $i/mined.h
-	@asld -o bin/mined $l/crtso.s mined1.s mined2.s $l/libc.a $l/end.s
+mined:	mined1.s mined2.s $(INC)/mined.h
+	@asld $(LDFLAGS) -o bin/mined $(l)/crtso.s mined1.s mined2.s $(LIB) $(l)/end.s
 
 shobj = sh1.s sh2.s sh3.s sh4.s sh5.s
-sh:	$(shobj) $i/sh.h
-	@asld -o bin/sh $l/crtso.s $(shobj) $l/libc.a $l/end.s
+sh:	$(shobj) $(INC)/sh.h
+	@asld $(LDFLAGS) -o bin/sh $(l)/crtso.s $(shobj) $(LIB) $(l)/end.s
 

--- a/fs/minix/makefile
+++ b/fs/minix/makefile
@@ -1,17 +1,21 @@
 # Use clang for the 16-bit fs build
 CC ?= clang
-CFLAGS= -w -F -T.
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -w -F -T.
+CFLAGS += -I$(INC)
 h=../h
-l=/usr/lib
+l=../lib
 
 obj =	main.s open.s read.s write.s pipe.s device.s \
 	path.s mount.s link.s super.s inode.s cache.s filedes.s \
 	stadir.s protect.s time.s misc.s utility.s table.s putc.s
 
-fs:	makefile   $l/head.s $(obj) $l/libc.a $l/end.s
+fs:	makefile   $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "Start linking FS.  /lib/cem will be removed to make space on RAM disk"
 	@rm -f /lib/cem /tmp/*
-	asld -o fs $l/head.s $(obj) $l/libc.a $l/end.s
+	asld $(LDFLAGS) -o fs $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "FS done.  Please restore /lib/cem manually"
 
 cache.s:	const.h type.h $h/const.h $h/type.h

--- a/fs/minix/makefile.at
+++ b/fs/minix/makefile.at
@@ -1,15 +1,19 @@
-CFLAGS= -w -F -T.
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -w -F -T.
+CFLAGS += -I$(INC)
 h=../h
-l=/usr/lib
+l=../lib
 
 obj =	main.s open.s read.s write.s pipe.s device.s \
 	path.s mount.s link.s super.s inode.s cache.s filedes.s \
 	stadir.s protect.s time.s misc.s utility.s table.s putc.s
 
-fs:	makefile   $l/head.s $(obj) $l/libc.a $l/end.s
+fs:	makefile   $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "Start linking FS.  "
 	@rm -f  /tmp/*
-	asld -o fs -T. $l/head.s $(obj) $l/libc.a $l/end.s
+	asld $(LDFLAGS) -o fs -T. $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "FS done.  "
 
 cache.s:	const.h type.h $h/const.h $h/type.h

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -3,7 +3,11 @@
 # correct driver.  If not specified the PC/XT driver is used.
 # Use clang to compile the kernel
 CC ?= clang
-CFLAGS = -O
+CFLAGS ?= -O
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS += -I$(INC)
 h=../h
 l=../lib
 
@@ -27,9 +31,9 @@ endif
 obj = mpx64.o idt64.o main.o proc.o system.o tty.o clock.o memory.o floppy.o wini.o \
       printer.o table.o klib64.o dmp.o paging.o syscall.o
 
-kernel:	makefile $(obj) $l/libc.a
+kernel:	makefile $(obj) $(LIB)
 	@echo "Start linking Kernel"
-	@ld -o kernel  $(obj) $l/libc.a $l/end.o
+	@ld $(LDFLAGS) -o kernel  $(obj) $(LIB) $l/end.o
 	@echo "Kernel done"
 
 # Compile klib64 from its C source

--- a/kernel/minix/makefile
+++ b/kernel/minix/makefile
@@ -3,17 +3,21 @@
 # PC or an AT.  You must do this even if you do not have a hard disk..
 # Use clang for the 16-bit kernel build
 CC ?= clang
-CFLAGS= -w -F -T.
+CFLAGS ?= -w -F -T.
+CFLAGS += -I$(INC)
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
 h=../h
-l=/usr/lib
+l=../lib
 
 obj = mpx88.c main.s proc.s system.s tty.s clock.s memory.s floppy.s wini.s  \
       printer.s table.s klib88.c dmp.s
 
-kernel:	makefile $(obj) $l/libc.a
+kernel:	makefile $(obj) $(LIB)
 	@echo "Start linking Kernel.  /lib/cem will be removed to make space on RAM disk"
 	@rm -f /lib/cem /tmp/*
-	@asld -o kernel  $(obj) $l/libc.a $l/end.s
+	@asld $(LDFLAGS) -o kernel  $(obj) $(LIB) $l/end.s
 	@echo "Kernel done.  Please restore /lib/cem manually"
 
 clock.s:	const.h type.h $h/const.h $h/type.h

--- a/kernel/minix/makefile.at
+++ b/kernel/minix/makefile.at
@@ -1,14 +1,18 @@
-CFLAGS= -w -F -T.
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -w -F -T.
+CFLAGS += -I$(INC)
 h=../h
-l=/usr/lib
+l=../lib
 
 obj = mpx88.c main.s proc.s system.s tty.s clock.s memory.s floppy.s wini.s  \
       printer.s table.s klib88.c dmp.s
 
-kernel:	makefile $(obj) $l/libc.a
+kernel:	makefile $(obj) $(LIB)
 	@echo "Start linking Kernel.  "
 	@rm -f  /tmp/*
-	@asld -o kernel -T.  $(obj) $l/libc.a $l/end.s
+	@asld $(LDFLAGS) -o kernel -T.  $(obj) $(LIB) $l/end.s
 	@echo "Kernel done.  "
 
 clock.s:	const.h type.h $h/const.h $h/type.h

--- a/mm/makefile
+++ b/mm/makefile
@@ -1,15 +1,19 @@
 # Use clang to compile mm
 CC ?= clang
-CFLAGS= -O
+CFLAGS ?= -O
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS += -I$(INC)
 h=../h
 l=../lib
 
 obj =	main.o forkexit.o break.o exec.o signal.o getset.o  \
 	alloc.o utility.o table.o paging.o vm.o putc.o 
 
-mm:	makefile  $l/head.o $(obj) $l/libc.a $l/end.o
+mm:	makefile  $l/head.o $(obj) $(LIB) $l/end.o
 	@echo "Start linking MM"
-	@ld -o mm $l/head.o $(obj) $l/libc.a $l/end.o
+	@ld $(LDFLAGS) -o mm $l/head.o $(obj) $(LIB) $l/end.o
 	@echo "MM done"
 
 

--- a/mm/minix/makefile
+++ b/mm/minix/makefile
@@ -1,16 +1,20 @@
 # Use clang for the 16-bit mm build
 CC ?= clang
-CFLAGS = -w -F -T.
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -w -F -T.
+CFLAGS += -I$(INC)
 h=../h
-l=/usr/lib
+l=../lib
 
 obj =	main.s forkexit.s break.s exec.s signal.s getset.s  \
 	alloc.s utility.s table.s putc.s 
 
-mm:	makefile    $l/head.s $(obj) $l/libc.a $l/end.s
+mm:	makefile    $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "Start linking MM.  /lib/cem will be removed to make space on RAM disk"
 	@rm -f /lib/cem /tmp/*
-	@asld -o mm $l/head.s $(obj) $l/libc.a $l/end.s
+	@asld $(LDFLAGS) -o mm $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "MM done.  Please restore /lib/cem manually"
 
 

--- a/mm/minix/makefile.at
+++ b/mm/minix/makefile.at
@@ -1,14 +1,18 @@
-CFLAGS = -w -F -T.
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -w -F -T.
+CFLAGS += -I$(INC)
 h=../h
-l=/usr/lib
+l=../lib
 
 obj =	main.s forkexit.s break.s exec.s signal.s getset.s  \
 	alloc.s utility.s table.s putc.s 
 
-mm:	makefile    $l/head.s $(obj) $l/libc.a $l/end.s
+mm:	makefile    $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "Start linking MM.  "
 	@rm -f /tmp/*
-	@asld -o mm -T. $l/head.s $(obj) $l/libc.a $l/end.s
+	@asld $(LDFLAGS) -o mm -T. $l/head.s $(obj) $(LIB) $l/end.s
 	@echo "MM done.  "
 
 

--- a/test/makefile
+++ b/test/makefile
@@ -5,10 +5,16 @@
 
 # Use clang for building the test programs
 CC ?= clang
-CFLAGS = -O -I../include
+# Base compiler flags; users may extend these when invoking make
+CFLAGS ?= -O
+# Always search the shared include directory
+CFLAGS += -I$(INC)
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
 
 # Build the requested test program using the host C compiler.
 # The variable 'f' specifies the base filename of the test.
-file: $(f).c
-	$(CC) $(CFLAGS) -o $(f) $(f).c
+file: $(f).c $(LIB)
+        $(CC) $(CFLAGS) -o $(f) $(f).c $(LIB) $(LDFLAGS)
 

--- a/test/minix/makefile
+++ b/test/minix/makefile
@@ -5,10 +5,14 @@
 # Use clang for the 16-bit tests
 CC ?= clang
 
-l=/usr/lib
+l=../lib
 
-CFLAGS = -I/usr/include -F
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -F
+CFLAGS += -I$(INC)
 
-file:	$l/libc.a $f.s
-	@asld -o $f $l/crtso.s  $f.s $l/libc.a $l/end.s
+file:	$(LIB) $(f).s
+	@asld $(LDFLAGS) -o $f $(l)/crtso.s  $(f).s $(LIB) $(l)/end.s
 

--- a/tools/makefile
+++ b/tools/makefile
@@ -1,7 +1,12 @@
 # Use clang to build the tooling
 CC ?= clang
 l=../lib
-CFLAGS = -O -DPCIX
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+# Default optimization flags
+CFLAGS ?= -O -DPCIX
+CFLAGS += -I$(INC)
 
 all:
 	make init
@@ -10,8 +15,8 @@ all:
 	make mkfs
 	make fsck
 
-init:	$l/libc.a init.o $l/head.o
-	ld -o init  $l/head.o init.o $l/libc.a  $l/end.o
+init:	$(LIB) init.o $l/head.o
+	ld $(LDFLAGS) -o init  $l/head.o init.o $(LIB)  $l/end.o
 	@echo init done.
 
 # bootblok.c is the source of the MINIX boot block.  The bootblock is the
@@ -28,21 +33,21 @@ init:	$l/libc.a init.o $l/head.o
 # probably that you have not made a good boot block.
 bootblok:	bootblok.c
 	# Compile the boot block using the C source
-	$(CC) $(CFLAGS) -o bootblok bootblok.c
-	$(CC) $(CFLAGS) -o bootblokgen bootblok.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o bootblok bootblok.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o bootblokgen bootblok.c
 	@echo bootblok done.
 build:	build.o
-	$(CC) -o build build.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o build build.o
 	@echo build done.
 
 mkfs:	mkfs.o
-	$(CC) -o mkfs mkfs.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o mkfs mkfs.o
 	@echo mkfs done.
 mkfs.o:	mkfs.c
-	$(CC) -c -O -DUNIX mkfs.c
+	$(CC) $(CFLAGS) -DUNIX -c mkfs.c
 
 fsck:	fsck.o fsck1.o diskio.o
-	ld -o fsck  fsck1.o fsck.o diskio.o $l/libc.a
+	ld $(LDFLAGS) -o fsck  fsck1.o fsck.o diskio.o $(LIB)
 	@echo fsck done.
 fsck1.o:	fsck1.c
 	$(CC) $(CFLAGS) -c fsck1.c

--- a/tools/minix/makefile
+++ b/tools/minix/makefile
@@ -1,7 +1,11 @@
 # Use clang for the legacy tooling
 CC ?= clang
-l=/usr/lib
-CFLAGS = -F
+l=../lib
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -F
+CFLAGS += -I$(INC)
 
 all:
 	make init
@@ -10,8 +14,8 @@ all:
 	make mkfs
 	make fsck
 
-init:	$l/libc.a init.s $l/head.s
-	asld -o init  $l/head.s init.s $l/libc.a  $l/end.s
+init:	$(LIB) init.s $l/head.s
+	asld $(LDFLAGS) -o init  $l/head.s init.s $(LIB)  $l/end.s
 	@echo init done.
 
 # bootblok.c is the source of the MINIX boot block.  The bootblock is the
@@ -27,21 +31,21 @@ init:	$l/libc.a init.s $l/head.s
 # diskette does not start out by printing 'Booting MINIX 1.0' the problem is
 # probably that you have not made a good boot block.
 bootblok:	bootblok.c
-	$(CC) $(CFLAGS) -o bootblok bootblok.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o bootblok bootblok.c
 	@echo bootblok done.
 
 build:	build.c
-	$(CC) $(CFLAGS) -o build build.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o build build.c
 	@echo build done.
 mkfs: mkfs.c
-	$(CC) $(CFLAGS) -DUNIX -o mkfs mkfs.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -DUNIX -o mkfs mkfs.c
 	@echo mkfs done.
 fsck:	fsck.s fsck1.s
 	@echo "Start linking fsck.  /lib/cem will be removed to make space on RAM disk"
-	asld -o fsck  fsck1.s fsck.s $l/libc.a $l/end.s
+	asld $(LDFLAGS) -o fsck  fsck1.s fsck.s $(LIB) $l/end.s
 	@echo fsck done. Please restore /lib/cem manually.
 fsck.s: fsck.c
-	$(CC) -c -w -F -T. fsck.c
+	$(CC) $(CFLAGS) -c fsck.c
 	
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces

--- a/tools/minix/makefile.at
+++ b/tools/minix/makefile.at
@@ -1,5 +1,9 @@
-l=/usr/lib
-CFLAGS = -F
+l=../lib
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS ?= -F
+CFLAGS += -I$(INC)
 
 all:
 	make init
@@ -8,8 +12,8 @@ all:
 	make mkfs
 	make fsck
 
-init:	$l/libc.a init.s $l/head.s
-	asld -o init  $l/head.s init.s $l/libc.a  $l/end.s
+init:	$(LIB) init.s $l/head.s
+	asld $(LDFLAGS) -o init  $l/head.s init.s $(LIB)  $l/end.s
 	@echo init done.
 
 # bootblok.s is the source of the MINIX boot block.  The bootblock is the
@@ -25,27 +29,27 @@ init:	$l/libc.a init.s $l/head.s
 # diskette does not start out by printing 'Booting MINIX 1.0' the problem is
 # probably that you have not made a good boot block.
 bootblok:	bootblok.s
-	@asld $l/crtso.s bootblok.s $l/end.s
+	@asld $(LDFLAGS) $l/crtso.s bootblok.s $l/end.s
 	@dd if=a.out of=bootblok bs=16w skip=1 count=16 2>/dev/null
 	@rm a.out
 	@echo bootblok done.
 
 build:	build.s
-	cc -o build build.s
+	$(CC) $(CFLAGS) $(LDFLAGS) -o build build.s
 	@echo build done.
 
 mkfs:	mkfs.s
-	cc -o mkfs mkfs.s
+	$(CC) $(CFLAGS) $(LDFLAGS) -o mkfs mkfs.s
 	@echo mkfs done.
 mkfs.s:	mkfs.c
-	cc -c -DUNIX mkfs.c
+	$(CC) $(CFLAGS) -c -DUNIX mkfs.c
 
 fsck:	fsck.s fsck1.s
 	@echo "Start linking fsck.  "
-	asld -o fsck -T.  fsck1.s fsck.s $l/libc.a $l/end.s
+	asld $(LDFLAGS) -o fsck -T.  fsck1.s fsck.s $(LIB) $l/end.s
 	@echo fsck done. 
 fsck.s: fsck.c
-	cc -c -w -F -T. fsck.c
+	$(CC) $(CFLAGS) -c fsck.c
 
 # 'make image'  combines the bootblock, kernel, memory manager, file 
 # system, init and fsck into a single file, called image.  Each of these pieces


### PR DESCRIPTION
## Summary
- switch makefiles to `../include` and `../lib/lib.a`
- allow `CC`, `CFLAGS` and `LDFLAGS` overrides
- document new build variables

## Testing
- `make -C lib` *(fails: implicit declarations and missing headers)*