### PR TITLE
Add simple CTest unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential nasm
     - name: Configure
-      run: cmake -B build
+      run: cmake -B build -DBUILD_SYSTEM=OFF
     - name: Build
       run: cmake --build build -- -j$(nproc)
-    - name: Run sample tests
+    - name: Run unit tests
       run: |
-        for t in $(sed '/^echo/d' test/run); do
-          make -C test f=$t
-          ./test/$t
-        done
+        ctest --test-dir build --output-on-failure
 
   clang-tools:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,18 @@ else()
   set(WINI_DRIVER pc)
 endif()
 
-add_subdirectory(lib)
-add_subdirectory(kernel)
-add_subdirectory(mm)
-add_subdirectory(fs)
-add_subdirectory(commands)
-add_subdirectory(tools)
+option(BUILD_SYSTEM "Build Minix system components" ON)
+
+if(BUILD_SYSTEM)
+  add_subdirectory(lib)
+  add_subdirectory(kernel)
+  add_subdirectory(mm)
+  add_subdirectory(fs)
+  add_subdirectory(commands)
+  add_subdirectory(tools)
+endif()
+
+# Enable unit testing and add the tests directory
+enable_testing()
+add_subdirectory(tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Unit tests for Minix library routines and basic system calls
+
+# Library routine tests compile selected sources directly
+add_executable(lib_test
+    test_lib.c
+    ${CMAKE_SOURCE_DIR}/lib/strlen.c
+    ${CMAKE_SOURCE_DIR}/lib/strcmp.c
+    ${CMAKE_SOURCE_DIR}/lib/rand.c
+)
+
+target_compile_options(lib_test PRIVATE -std=c90 -fno-builtin)
+
+add_test(NAME lib_test COMMAND lib_test)
+
+# System call tests rely on the host C library only
+add_executable(syscall_test test_syscall.c)
+add_test(NAME syscall_test COMMAND syscall_test)

--- a/tests/test_lib.c
+++ b/tests/test_lib.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+/* Prototype for strlen from the Minix library. */
+int strlen(char *s);
+/* Prototype for strcmp from the Minix library. */
+int strcmp(char *s1, char *s2);
+/* Prototype for rand from the Minix library. */
+int rand(void);
+
+/* Verify basic behavior of strlen, strcmp and rand. */
+int main(void) {
+    /* strlen should count the characters in the string. */
+    assert(strlen("hello") == 5);
+    /* strcmp should report equality for identical strings. */
+    assert(strcmp("a", "a") == 0);
+    /* rand should produce a non-negative value. */
+    int r = rand();
+    assert(r >= 0);
+    return 0;
+}

--- a/tests/test_syscall.c
+++ b/tests/test_syscall.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Exercise simple open/read/write/close syscalls. */
+int main(void) {
+    const char *msg = "hi";
+    int fd = open("tempfile", O_RDWR | O_CREAT | O_TRUNC, 0600);
+    assert(fd >= 0);
+    assert(write(fd, msg, 2) == 2);
+    lseek(fd, 0, SEEK_SET);
+    char buf[3] = {0};
+    assert(read(fd, buf, 2) == 2);
+    assert(strcmp(buf, msg) == 0);
+    close(fd);
+    unlink("tempfile");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a `tests` directory with basic unit tests
- add an option to disable building the full system
- run `ctest` in CI

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build`
- `ctest --output-on-failure`