### PR TITLE
Implement safe memory wrappers

### DIFF
--- a/commands/gres.c
+++ b/commands/gres.c
@@ -19,6 +19,7 @@
 
 #include "stdio.h"
 #include "regexp.h"
+#include "../include/lib.h"
 
 #define MAXLINE (1024)
 
@@ -119,8 +120,6 @@ getbuf(exp, repstr)
 regexp *exp;
 char *repstr;
 {
-	char *malloc();
-	void free();
 	static bufsize = 0;
 	static char *buf = 0;
 	int guess = 10;
@@ -144,10 +143,10 @@ char *repstr;
 		}
 		repstr++;
 	}
-	if(bufsize < guess) {
-		if(buf != 0)
-			free((char *)buf);
-		buf = malloc(guess);
+        if(bufsize < guess) {
+                if(buf != 0)
+                        safe_free((char *)buf);
+                buf = safe_malloc(guess);
 	}
 	return buf;
 }

--- a/commands/make.c
+++ b/commands/make.c
@@ -1,5 +1,6 @@
 #include "stdio.h"
 #include "errno.h"
+#include "../include/lib.h"
 extern int errno;
 
 #ifdef LC
@@ -504,9 +505,9 @@ struct m_preq   ma;
 	if (defnp->howto != NULL)   /* we had instructions */
 	    madesomething = TRUE;
     }
-    if ( m_comp != NULL ) free( m_comp );
-    if ( m_ood  != NULL ) free( m_ood );
-    if ( m_obj  != NULL ) free( m_obj );
+    if ( m_comp != NULL ) safe_free( m_comp );
+    if ( m_ood  != NULL ) safe_free( m_ood );
+    if ( m_obj  != NULL ) safe_free( m_obj );
     return(defnp->modified);
 
 }
@@ -1041,7 +1042,7 @@ char *ptr;
     strcat(ptr," ");
     strcat(ptr,f2);
     strcat(ptr,f3);
-    if ( f1 != NULL ) free( f1 );
+    if ( f1 != NULL ) safe_free( f1 );
     return( ptr );
 }
 
@@ -1744,19 +1745,19 @@ struct llist *ptr;
 
     if ( head == NULL ) return;
     else if ( head->next == NULL ) {
-	free( head->name );
-	free( (char *)head );
+        safe_free( head->name );
+        safe_free( (char *)head );
 	return;
     }
     else {
 	while ( TRUE ) {
 	    for ( ptr = head; ptr->next->next != NULL; ptr = ptr->next ) ;
-	    free(ptr->next->name);
-	    free((char *)ptr->next);
+            safe_free(ptr->next->name);
+            safe_free((char *)ptr->next);
 	    ptr->next = NULL;
 	    if ( ptr == head ) {
-		free( ptr->name );
-		free( (char *)ptr);
+                safe_free( ptr->name );
+                safe_free( (char *)ptr);
 		return;
 	    }
 	}
@@ -1860,7 +1861,7 @@ char wholenam[INMAXSH];
 	execv(wholenam,vargs);
 	done( -1 );
     }
-    free( (char *)vargs );
+    safe_free( (char *)vargs );
     free_list( largs );
 
     if ( pid < 0 ) {
@@ -1880,7 +1881,7 @@ char wholenam[INMAXSH];
 	    perror(whoami);
 	    panicstop();
     }
-    free( (char *)vargs );
+    safe_free( (char *)vargs );
     free_list( largs );
     ccode = wait();
     return( pr_warning(&ccode) );
@@ -1982,20 +1983,17 @@ struct llist *arglist;
 char *get_mem(size)
 UI size;
 {
-char *p,*malloc();
+char *p;
 
-    if ((p = malloc(size)) == 0)
-	panic("Ran out of memory");
+    p = safe_malloc(size);
     return(p);
 }
 
 struct llist *MkListMem()
 {
 struct llist *p;
-char *malloc();
 
-    if ((p = (struct llist *)malloc(sizeof(struct llist))) == 0 )
-	panic("Ran out of memory");
+    p = (struct llist *)safe_malloc(sizeof(struct llist));
     return(p);
 }
 

--- a/commands/mined1.c
+++ b/commands/mined1.c
@@ -407,6 +407,7 @@
 #include "mined.h"
 #include "signal.h"
 #include "sgtty.h"
+#include "../include/lib.h"
 #ifdef UNIX
 #include <errno.h>
 #else
@@ -1241,15 +1242,14 @@ register char *p;
 char *alloc(bytes)
 int bytes;
 {
-  extern char *malloc();
 
-  return malloc((unsigned) bytes);
+  return safe_malloc((unsigned) bytes);
 }
 
 free_space(p)
 char *p;
 {
-  free(p);
+  safe_free(p);
 }
 #endif lint
 

--- a/fs/compat.c
+++ b/fs/compat.c
@@ -8,6 +8,7 @@
 #include "../h/type.h"
 #include "extent.h"
 #include "inode.h"
+#include "../include/lib.h"
 
 /*===========================================================================*
  *                              init_extended_inode                           *
@@ -32,7 +33,6 @@ PUBLIC void init_extended_inode(struct inode *ip)
 PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count)
 {
 
-  extern char *malloc(); /* Memory allocator provided by lib. */
   extent *table;         /* Pointer to newly allocated extent list. */
   unsigned short i;      /* Loop counter for initialization.       */
 
@@ -44,7 +44,7 @@ PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count)
   }
 
   /* Allocate memory for the extent table. */
-  table = (extent *)malloc((unsigned)(count * sizeof(extent)));
+  table = (extent *)safe_malloc((unsigned)(count * sizeof(extent)));
   if (table == NIL_EXTENT) {
     /* Allocation failed.  Ensure inode fields remain clear. */
     ip->i_extents = NIL_PTR;

--- a/include/lib.h
+++ b/include/lib.h
@@ -15,3 +15,7 @@ extern int callx(int proc, int syscallnr);
 extern int len(char *s);
 extern int errno;
 extern int begsig(void);            /* interrupts all vector here */
+
+/* Memory allocation wrappers */
+void *safe_malloc(size_t size);
+void safe_free(void *ptr);

--- a/lib/fclose.c
+++ b/lib/fclose.c
@@ -1,4 +1,5 @@
 #include "../include/stdio.h"
+#include "../include/lib.h"
 
 fclose(fp)
 FILE *fp;
@@ -14,9 +15,9 @@ FILE *fp;
 		return(EOF);
 	fflush(fp);
 	close(fp->_fd);
-	if ( testflag(fp,IOMYBUF) && fp->_buf )
-		free( fp->_buf );
-	free(fp);
+        if ( testflag(fp,IOMYBUF) && fp->_buf )
+                safe_free( fp->_buf );
+        safe_free(fp);
 	return(NULL);
 }
 

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -1,4 +1,5 @@
 #include "../include/stdio.h"
+#include "../include/lib.h"
 
 #define PMODE 0644
 
@@ -14,7 +15,6 @@ FILE *fopen(const char *name, const char *mode)
 {
     int i;          /* index into _io_table */
     FILE *fp;       /* resulting stream */
-    char *malloc();
     int fd;         /* file descriptor from open/creat */
     int flags = 0;  /* stream flags */
 
@@ -58,20 +58,15 @@ FILE *fopen(const char *name, const char *mode)
 
 
     /* Allocate the FILE structure. */
-    fp = (FILE *)malloc(sizeof(FILE));
-    if (fp == NULL)
-        return NULL;
+    fp = (FILE *)safe_malloc(sizeof(FILE));
 
 
     /* Initialize the stream structure. */
     fp->_count = 0;
     fp->_fd = fd;
     fp->_flags = flags;
-    fp->_buf = malloc(BUFSIZ);
-    if (fp->_buf == NULL)
-        fp->_flags |= UNBUFF;    /* fallback to unbuffered if allocation fails */
-    else
-        fp->_flags |= IOMYBUF;
+    fp->_buf = safe_malloc(BUFSIZ);
+    fp->_flags |= IOMYBUF;
 
     fp->_ptr = fp->_buf;
     _io_table[i] = fp;

--- a/lib/minix/setjmp.c
+++ b/lib/minix/setjmp.c
@@ -1,5 +1,6 @@
 #include <setjmp.h>
 #include <stdlib.h>
+#include "../../include/lib.h"
 #include "../../include/setjmp.h"
 
 /*
@@ -8,10 +9,7 @@
  */
 PUBLIC int _setjmp(jmp_buf env)
 {
-    jmp_buf *real = malloc(sizeof(jmp_buf));
-    if (!real) {
-        return -1;
-    }
+    jmp_buf *real = safe_malloc(sizeof(jmp_buf));
     *(jmp_buf **)env = real;
     return setjmp(*real);
 }

--- a/lib/regexp.c
+++ b/lib/regexp.c
@@ -28,6 +28,7 @@
 
 #include "../include/stdio.h"
 #include "../include/regexp.h"
+#include "../include/lib.h"
 
 /*
  * The first byte of the regexp internal "program" is actually this magic
@@ -198,7 +199,6 @@ char *exp;
   register char *longest;
   register int len;
   int flags;
-  extern char *malloc();
 
   if (exp == NULL)
 	FAIL("NULL argument");
@@ -217,9 +217,7 @@ char *exp;
 	FAIL("regexp too big");
 
   /* Allocate space. */
-  r = (regexp *)malloc(sizeof(regexp) + (unsigned)regsize);
-  if (r == NULL)
-	FAIL("out of space");
+  r = (regexp *)safe_malloc(sizeof(regexp) + (unsigned)regsize);
 
   /* Second pass: emit code. */
   regparse = exp;

--- a/lib/safe_alloc.c
+++ b/lib/safe_alloc.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../include/lib.h"
+
+/* Allocate memory and abort on failure. */
+void *safe_malloc(size_t size)
+{
+    void *ptr = malloc(size);
+    if (ptr == NULL) {
+        fprintf(stderr, "out of memory\n");
+        exit(1);
+    }
+    return ptr;
+}
+
+/* Free memory if pointer not NULL. */
+void safe_free(void *ptr)
+{
+    if (ptr != NULL) {
+        free(ptr);
+    }
+}

--- a/lib/setbuf.c
+++ b/lib/setbuf.c
@@ -1,12 +1,13 @@
-#include	"../include/stdio.h"
+#include "../include/stdio.h"
+#include "../include/lib.h"
 
 
 setbuf(iop, buffer)
 FILE *iop;
 char *buffer;
 {
-	if ( iop->_buf && testflag(iop,IOMYBUF) )
-		free(iop->_buf);
+        if ( iop->_buf && testflag(iop,IOMYBUF) )
+                safe_free(iop->_buf);
 
 	iop->_flags &= ~(IOMYBUF | UNBUFF | PERPRINTF);
 

--- a/lib/setjmp.c
+++ b/lib/setjmp.c
@@ -1,5 +1,6 @@
 #include <setjmp.h>
 #include <stdlib.h>
+#include "../include/lib.h"
 #include "../include/setjmp.h"
 
 /*
@@ -8,10 +9,7 @@
  */
 PUBLIC int _setjmp(jmp_buf env)
 {
-    jmp_buf *real = malloc(sizeof(jmp_buf));
-    if (!real) {
-        return -1;
-    }
+    jmp_buf *real = safe_malloc(sizeof(jmp_buf));
     *(jmp_buf **)env = real;
     return setjmp(*real);
 }

--- a/tools/fsck.c
+++ b/tools/fsck.c
@@ -4,6 +4,7 @@
 #include "../h/type.h"
 #include "../fs/const.h"
 #include "../fs/type.h"
+#include "../include/lib.h"
 
 /* #define DOS			/* compile to run under MS-DOS */
 #define STANDALONE		/* compile for the boot-diskette */
@@ -499,7 +500,7 @@ unsigned nelem, elsize;
 dealloc(p)
 char *p;
 {
-	free(p);
+        safe_free(p);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- add `safe_malloc` and `safe_free` in library
- expose wrappers in `lib.h`
- use wrappers in subsystems and commands

## Testing
- `make -C test f=test0` *(fails: missing separator)*