### PR TITLE
Add clang-tidy utility

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 Checks: '-*,bugprone-*,portability-*'
 WarningsAsErrors: '*'
-FormatStyle: file
+FormatStyle: none
 HeaderFilterRegex: '.*'

--- a/lib/strcmp.c
+++ b/lib/strcmp.c
@@ -1,3 +1,7 @@
+/*
+ * Compare two strings and return the difference between
+ * the first differing characters or zero if they match.
+ */
 int strcmp(s1, s2)
 register char *s1, *s2;
 {

--- a/lib/strlen.c
+++ b/lib/strlen.c
@@ -1,3 +1,6 @@
+/*
+ * Compute the length of a string.
+ */
 int strlen(s)
 char *s;
 {

--- a/tools/run_clang_tidy.sh
+++ b/tools/run_clang_tidy.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Run clang-tidy across the repository with C90 compliance.
+# This script generates compile_commands if needed and then
+# executes clang-tidy with automatic fixes. Comment lines are
+# left untouched since clang-tidy is invoked with FormatStyle=none.
+
+set -e
+BUILD_DIR="build"
+
+# Create build directory and compile database if missing
+if [ ! -f "$BUILD_DIR/compile_commands.json" ]; then
+    cmake -S . -B "$BUILD_DIR" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+fi
+
+# Find all C source files excluding the build directory and run clang-tidy
+find . -name '*.c' -not -path "./$BUILD_DIR/*" \
+    | xargs -r clang-tidy -p "$BUILD_DIR" -fix -format-style=none -extra-arg=-std=c90 "$@"


### PR DESCRIPTION
## Summary
- disable automatic formatting in `.clang-tidy`
- document `strlen` and `strcmp`
- add `tools/run_clang_tidy.sh` helper

## Testing
- `cmake --build build` *(fails: conflicting types for built-in functions)*
- `ctest --test-dir build --output-on-failure` *(fails: executables not found)*