### PR TITLE
Update ascii_tree typing

### DIFF
--- a/tools/ascii_tree.py
+++ b/tools/ascii_tree.py
@@ -1,13 +1,13 @@
 import argparse
 import os
-from typing import List
+from typing import List, Optional
 
 
 def list_directory(
     path: str,
     prefix: str = "",
     show_hidden: bool = False,
-    exclude: List[str] | None = None,
+    exclude: Optional[List[str]] = None,
 ) -> List[str]:
     """Recursively build an ASCII representation of ``path``.
 
@@ -17,6 +17,10 @@ def list_directory(
         Directory to walk.
     prefix:
         Indentation prefix for the current level.
+    show_hidden:
+        Whether to include hidden files.
+    exclude:
+        A list of file or directory names to skip.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- add missing Optional import in ascii_tree
- switch exclude arg to use Optional[List[str]]
- expand list_directory docstring

## Testing
- `python3 -m py_compile tools/ascii_tree.py`
- `clang-format -n tools/ascii_tree.py` *(fails to format due to unsupported language)*