### PR TITLE
Fix old libc prototypes

### DIFF
--- a/lib/abs.c
+++ b/lib/abs.c
@@ -1,3 +1,9 @@
-abs(i){
-  return i < 0 ? -i : i;
+/* Implementation of the standard abs() function. */
+
+#include <stdlib.h>
+
+/* Return the absolute value of the integer argument. */
+int abs(int i) {
+    /* Use a simple ternary expression to select the correct sign. */
+    return (i < 0) ? -i : i;
 }

--- a/lib/atoi.c
+++ b/lib/atoi.c
@@ -1,40 +1,49 @@
-#define isascii(c)	(((unsigned) (c) & 0xFF) < 0200)
+/* Implementation of the standard atoi() function. */
 
-/* For all the following functions the parameter must be ASCII */
+/* Local character classification helpers. */
+#define isascii(c) (((unsigned)(c) & 0xFF) < 0200)
 
-#define _between(a,b,c)	((unsigned) ((b) - (a)) < (c) - (a))
+/* For all the following functions the parameter must be ASCII. */
+#define _between(a, b, c) ((unsigned)((b) - (a)) < (c) - (a))
 
-#define isupper(c)	_between('A', c, 'Z')
-#define islower(c)	_between('a', c, 'z')
-#define isdigit(c)	_between('0', c, '9')
-#define isprint(c)	_between(' ', c, '~')
+#define isupper(c) _between('A', c, 'Z')
+#define islower(c) _between('a', c, 'z')
+#define isdigit(c) _between('0', c, '9')
+#define isprint(c) _between(' ', c, '~')
 
-/* The others are problematic as the parameter may only be evaluated once */
+/* The others are problematic as the parameter may only be evaluated once. */
+static _c_; /* used to store the evaluated parameter */
 
-static _c_;		/* used to store the evaluated parameter */
+#define isalpha(c) (isupper(_c_ = (c)) || islower(_c_))
+#define isalnum(c) (isalpha(c) || isdigit(_c_))
+#define _isblank(c) ((_c_ = (c)) == ' ' || _c_ == '\t')
+#define isspace(c) (_isblank(c) || _c_ == '\r' || _c_ == '\n' || _c_ == '\f')
+#define iscntrl(c) ((_c_ = (c)) == 0177 || _c_ < ' ')
 
-#define isalpha(c)	(isupper(_c_ = (c)) || islower(_c_))
-#define isalnum(c)	(isalpha(c) || isdigit(_c_))
-#define _isblank(c)	((_c_ = (c)) == ' ' || _c_ == '\t')
-#define isspace(c)	(_isblank(c) || _c_=='\r' || _c_=='\n' || _c_=='\f')
-#define iscntrl(c)	((_c_ = (c)) == 0177 || _c_ < ' ')
+#include <stdlib.h>
 
-atoi(s)
-register char *s;
-{
-  register int total = 0;
-  register unsigned digit;
-  register minus = 0;
+/* Convert a numeric string to an integer. */
+int atoi(const char *s) {
+    int total = 0;  /* running total */
+    unsigned digit; /* current digit */
+    int minus = 0;  /* track a leading '-' */
 
-  while (isspace(*s))
-	s++;
-  if (*s == '-') {
-	s++;
-	minus = 1;
-  }
-  while ((digit = *s++ - '0') < 10) {
-	total *= 10;
-	total += digit;
-  }
-  return(minus ? -total : total);
+    /* Skip leading whitespace characters. */
+    while (isspace(*s)) {
+        s++;
+    }
+
+    /* Handle optional leading minus sign. */
+    if (*s == '-') {
+        s++;
+        minus = 1;
+    }
+
+    /* Process digits until a non-digit is encountered. */
+    while ((digit = *s++ - '0') < 10) {
+        total *= 10;
+        total += digit;
+    }
+
+    return minus ? -total : total;
 }

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -1,7 +1,12 @@
+/* Simple linear congruential random number generator. */
+
+#include <stdlib.h>
+
+/* Seed value used by rand(). */
 static long seed = 1L;
 
-int rand()
-{
-  seed = (1103515245L * seed + 12345) & 0x7FFFFFFF;
-  return((int) (seed & 077777));
+/* Return a pseudo-random integer in the range [0, 32767]. */
+int rand(void) {
+    seed = (1103515245L * seed + 12345) & 0x7FFFFFFF;
+    return (int)(seed & 077777);
 }

--- a/lib/strcmp.c
+++ b/lib/strcmp.c
@@ -1,16 +1,16 @@
-/*
- * Compare two strings and return the difference between
- * the first differing characters or zero if they match.
- */
-int strcmp(s1, s2)
-register char *s1, *s2;
-{
-/* Compare 2 strings. */
+/* Compare two strings and return the difference between the first
+ * differing characters or zero if they match. */
 
-  while (1) {
-	if (*s1 != *s2) return(*s1 - *s2);
-	if (*s1 == 0) return(0);
-	s1++;
-	s2++;
-  }
+#include <string.h>
+
+/* Lexicographically compare s1 and s2. */
+int strcmp(const char *s1, const char *s2) {
+    while (1) {
+        if (*s1 != *s2)
+            return (*s1 - *s2); /* return difference when chars differ */
+        if (*s1 == '\0')
+            return 0; /* reached end of both strings */
+        s1++;
+        s2++;
+    }
 }

--- a/lib/strlen.c
+++ b/lib/strlen.c
@@ -1,13 +1,16 @@
-/*
- * Compute the length of a string.
- */
-int strlen(s)
-char *s;
-{
-/* Return length of s. */
+/* Compute the length of a string. */
 
-  char *original = s;
+#include <string.h>
 
-  while (*s != 0) s++;
-  return(s - original);
+/* Return the number of characters in the string s. */
+size_t strlen(const char *s) {
+    const char *original = s; /* keep starting position */
+
+    /* Walk forward until the terminating null byte. */
+    while (*s != '\0') {
+        s++;
+    }
+
+    /* Difference gives the length. */
+    return (size_t)(s - original);
 }

--- a/lib/write.c
+++ b/lib/write.c
@@ -1,8 +1,8 @@
 #include "../include/lib.h"
+#include <unistd.h>
 
-PUBLIC int write(fd, buffer, nbytes)
-char *buffer;
-int nbytes;
-{
-  return callm1(FS, WRITE, fd, nbytes, 0, buffer, NIL_PTR, NIL_PTR);
+/* Perform the write() system call through the message interface. */
+ssize_t write(int fd, const void *buffer, size_t nbytes) {
+    /* Delegates to the low level message based syscall wrapper. */
+    return (ssize_t)callm1(FS, WRITE, fd, (int)nbytes, 0, (char *)buffer, NIL_PTR, NIL_PTR);
 }


### PR DESCRIPTION
## Summary
- add modern includes for standard C library functions
- convert K&R definitions to ANSI style
- make return types explicit
- format library sources with clang-format

## Testing
- `make -C lib abs.o atoi.o strlen.o strcmp.o rand.o write.o`