### PR TITLE
Fix headers and syscall wrappers

### DIFF
--- a/h/type.h
+++ b/h/type.h
@@ -1,3 +1,6 @@
+#ifndef TYPE_H
+#define TYPE_H
+
 /* Macros */
 #define MAX(a, b) (a > b ? a : b)
 #define MIN(a, b) (a < b ? a : b)
@@ -48,44 +51,44 @@ typedef int signed_clicks;    /* same length as phys_clicks, but signed */
 #define M3_STRING 14
 
 typedef struct {
-  int m1i1, m1i2, m1i3;
-  char *m1p1, *m1p2, *m1p3;
+    int m1i1, m1i2, m1i3;
+    char *m1p1, *m1p2, *m1p3;
 } mess_1;
 typedef struct {
-  int m2i1, m2i2, m2i3;
-  long m2l1, m2l2;
-  char *m2p1;
+    int m2i1, m2i2, m2i3;
+    long m2l1, m2l2;
+    char *m2p1;
 } mess_2;
 typedef struct {
-  int m3i1, m3i2;
-  char *m3p1;
-  char m3ca1[M3_STRING];
+    int m3i1, m3i2;
+    char *m3p1;
+    char m3ca1[M3_STRING];
 } mess_3;
 typedef struct {
-  long m4l1, m4l2, m4l3, m4l4;
+    long m4l1, m4l2, m4l3, m4l4;
 } mess_4;
 typedef struct {
-  char m5c1, m5c2;
-  int m5i1, m5i2;
-  long m5l1, m5l2, m5l3;
+    char m5c1, m5c2;
+    int m5i1, m5i2;
+    long m5l1, m5l2, m5l3;
 } mess_5;
 typedef struct {
-  int m6i1, m6i2, m6i3;
-  long m6l1;
-  int (*m6f1)();
+    int m6i1, m6i2, m6i3;
+    long m6l1;
+    int (*m6f1)();
 } mess_6;
 
 typedef struct {
-  int m_source; /* who sent the message */
-  int m_type;   /* what kind of message is it */
-  union {
-    mess_1 m_m1;
-    mess_2 m_m2;
-    mess_3 m_m3;
-    mess_4 m_m4;
-    mess_5 m_m5;
-    mess_6 m_m6;
-  } m_u;
+    int m_source; /* who sent the message */
+    int m_type;   /* what kind of message is it */
+    union {
+        mess_1 m_m1;
+        mess_2 m_m2;
+        mess_3 m_m3;
+        mess_4 m_m4;
+        mess_5 m_m5;
+        mess_6 m_m6;
+    } m_u;
 } message;
 
 #define MESS_SIZE (sizeof(message))
@@ -131,17 +134,19 @@ typedef struct {
 #define m6_f1 m_u.m_m6.m6f1
 
 struct mem_map {
-  vir_clicks mem_vir;   /* virtual address */
-  phys_clicks mem_phys; /* physical address */
-  vir_clicks mem_len;   /* length */
+    vir_clicks mem_vir;   /* virtual address */
+    phys_clicks mem_phys; /* physical address */
+    vir_clicks mem_len;   /* length */
 };
 
 struct copy_info { /* used by sys_copy(src, dst, bytes) */
-  int cp_src_proc;
-  int cp_src_space;
-  vir_bytes cp_src_vir;
-  int cp_dst_proc;
-  int cp_dst_space;
-  vir_bytes cp_dst_vir;
-  vir_bytes cp_bytes;
+    int cp_src_proc;
+    int cp_src_space;
+    vir_bytes cp_src_vir;
+    int cp_dst_proc;
+    int cp_dst_space;
+    vir_bytes cp_dst_vir;
+    vir_bytes cp_bytes;
 };
+
+#endif /* TYPE_H */

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -1,2 +1,16 @@
+#ifndef SETJMP_H
+#define SETJMP_H
+
+/*
+ * Minimal jmp_buf representation used by the legacy Minix sources.
+ * The buffer merely stores a pointer to the host jmp_buf allocated at
+ * runtime in the wrapper implementation.
+ */
 #define _JBLEN 3
 typedef int jmp_buf[_JBLEN];
+
+/* Prototypes for the host provided setjmp/longjmp functions. */
+int setjmp(void *env);
+void longjmp(void *env, int val);
+
+#endif /* SETJMP_H */

--- a/kernel/clock.c
+++ b/kernel/clock.c
@@ -25,215 +25,220 @@
  * it is certain that the task will be blocked when the timer goes off.
  */
 
-#include "../h/const.h"
-#include "../h/type.h"
 #include "../h/callnr.h"
 #include "../h/com.h"
+#include "../h/const.h"
 #include "../h/error.h"
 #include "../h/signal.h"
+#include "../h/type.h"
 #include "const.h"
-#include "type.h"
 #include "glo.h"
 #include "proc.h"
+#include "type.h"
 
 /* Constant definitions. */
-#define MILLISEC         100	/* how often to call the scheduler (msec) */
-#define SCHED_RATE (MILLISEC*HZ/1000)	/* number of ticks per schedule */
+#define MILLISEC 100                      /* how often to call the scheduler (msec) */
+#define SCHED_RATE (MILLISEC * HZ / 1000) /* number of ticks per schedule */
 
 /* Clock parameters. */
-#define TIMER0          0x40	/* port address for timer channel 0 */
-#define TIMER_MODE      0x43	/* port address for timer channel 3 */
-#define IBM_FREQ    1193182L	/* IBM clock frequency for setting timer */
-#define SQUARE_WAVE     0x36	/* mode for generating square wave */
+#define TIMER0 0x40       /* port address for timer channel 0 */
+#define TIMER_MODE 0x43   /* port address for timer channel 3 */
+#define IBM_FREQ 1193182L /* IBM clock frequency for setting timer */
+#define SQUARE_WAVE 0x36  /* mode for generating square wave */
 
 /* Clock task variables. */
-PRIVATE real_time boot_time;	/* time in seconds of system boot */
-PRIVATE real_time next_alarm;	/* probable time of next alarm */
-PRIVATE int sched_ticks = SCHED_RATE;	/* counter: when 0, call scheduler */
-PRIVATE struct proc *prev_ptr;	/* last user process run by clock task */
-PRIVATE message mc;		/* message buffer for both input and output */
-PRIVATE int (*watch_dog[NR_TASKS+1])();	/* watch_dog functions to call */
+PRIVATE real_time boot_time;              /* time in seconds of system boot */
+PRIVATE real_time next_alarm;             /* probable time of next alarm */
+PRIVATE int sched_ticks = SCHED_RATE;     /* counter: when 0, call scheduler */
+PRIVATE struct proc *prev_ptr;            /* last user process run by clock task */
+PRIVATE message mc;                       /* message buffer for both input and output */
+PRIVATE int (*watch_dog[NR_TASKS + 1])(); /* watch_dog functions to call */
+/* Forward declarations for internal helpers. */
+PRIVATE void do_setalarm(message *m_ptr);
+PRIVATE void do_get_time(void);
+PRIVATE void do_set_time(message *m_ptr);
+PRIVATE void do_clocktick(void);
+PRIVATE void accounting(void);
+PRIVATE void init_clock(void);
 
 /*===========================================================================*
  *				clock_task				     *
  *===========================================================================*/
-PUBLIC clock_task()
-{
-/* Main program of clock task.  It determines which of the 4 possible
- * calls this is by looking at 'mc.m_type'.   Then it dispatches.
- */
- 
-  int opcode;
+PUBLIC clock_task() {
+    /* Main program of clock task.  It determines which of the 4 possible
+     * calls this is by looking at 'mc.m_type'.   Then it dispatches.
+     */
 
-  init_clock();			/* initialize clock tables */
+    int opcode;
 
-  /* Main loop of the clock task.  Get work, process it, sometimes reply. */
-  while (TRUE) {
-     receive(ANY, &mc);		/* go get a message */
-     opcode = mc.m_type;	/* extract the function code */
+    init_clock(); /* initialize clock tables */
 
-     switch (opcode) {
-	case SET_ALARM:	 do_setalarm(&mc);	break;
-	case GET_TIME:	 do_get_time();		break;
-	case SET_TIME:	 do_set_time(&mc);	break;
-	case CLOCK_TICK: do_clocktick();	break;
-	default: panic("clock task got bad message", mc.m_type);
-     }
+    /* Main loop of the clock task.  Get work, process it, sometimes reply. */
+    while (TRUE) {
+        receive(ANY, &mc);  /* go get a message */
+        opcode = mc.m_type; /* extract the function code */
 
-    /* Send reply, except for clock tick. */
-    mc.m_type = OK;
-    if (opcode != CLOCK_TICK) send(mc.m_source, &mc);
-  }
+        switch (opcode) {
+        case SET_ALARM:
+            do_setalarm(&mc);
+            break;
+        case GET_TIME:
+            do_get_time();
+            break;
+        case SET_TIME:
+            do_set_time(&mc);
+            break;
+        case CLOCK_TICK:
+            do_clocktick();
+            break;
+        default:
+            panic("clock task got bad message", mc.m_type);
+        }
+
+        /* Send reply, except for clock tick. */
+        mc.m_type = OK;
+        if (opcode != CLOCK_TICK)
+            send(mc.m_source, &mc);
+    }
 }
-
 
 /*===========================================================================*
  *				do_setalarm				     *
  *===========================================================================*/
-PRIVATE do_setalarm(m_ptr)
-message *m_ptr;			/* pointer to request message */
-{
-/* A process wants an alarm signal or a task wants a given watch_dog function
- * called after a specified interval.  Record the request and check to see
- * it is the very next alarm needed.
- */
+PRIVATE void do_setalarm(message *m_ptr) {
+    /* A process wants an alarm signal or a task wants a given watch_dog function
+     * called after a specified interval.  Record the request and check to see
+     * it is the very next alarm needed.
+     */
 
-  register struct proc *rp;
-  int proc_nr;			/* which process wants the alarm */
-  long delta_ticks;		/* in how many clock ticks does he want it? */
-  int (*function)();		/* function to call (tasks only) */
+    register struct proc *rp;
+    int proc_nr;       /* which process wants the alarm */
+    long delta_ticks;  /* in how many clock ticks does he want it? */
+    int (*function)(); /* function to call (tasks only) */
 
-  /* Extract the parameters from the message. */
-  proc_nr = m_ptr->CLOCK_PROC_NR;	/* process to interrupt later */
-  delta_ticks = m_ptr->DELTA_TICKS;	/* how many ticks to wait */
-  function = m_ptr->FUNC_TO_CALL;	/* function to call (tasks only) */
-  rp = proc_addr(proc_nr);
-  mc.SECONDS_LEFT = (rp->p_alarm == 0L ? 0 : (rp->p_alarm - realtime)/HZ );
-  rp->p_alarm = (delta_ticks == 0L ? 0L : realtime + delta_ticks);
-  if (proc_nr < 0) watch_dog[-proc_nr] = function;
+    /* Extract the parameters from the message. */
+    proc_nr = m_ptr->CLOCK_PROC_NR;   /* process to interrupt later */
+    delta_ticks = m_ptr->DELTA_TICKS; /* how many ticks to wait */
+    function = m_ptr->FUNC_TO_CALL;   /* function to call (tasks only) */
+    rp = proc_addr(proc_nr);
+    mc.SECONDS_LEFT = (rp->p_alarm == 0L ? 0 : (rp->p_alarm - realtime) / HZ);
+    rp->p_alarm = (delta_ticks == 0L ? 0L : realtime + delta_ticks);
+    if (proc_nr < 0)
+        watch_dog[-proc_nr] = function;
 
-  /* Which alarm is next? */
-  next_alarm = MAX_P_LONG;
-  for (rp = &proc[0]; rp < &proc[NR_TASKS+NR_PROCS]; rp++)
-	if(rp->p_alarm != 0 && rp->p_alarm < next_alarm)next_alarm=rp->p_alarm;
-
+    /* Which alarm is next? */
+    next_alarm = MAX_P_LONG;
+    for (rp = &proc[0]; rp < &proc[NR_TASKS + NR_PROCS]; rp++)
+        if (rp->p_alarm != 0 && rp->p_alarm < next_alarm)
+            next_alarm = rp->p_alarm;
 }
-
 
 /*===========================================================================*
  *				do_get_time				     *
  *===========================================================================*/
-PRIVATE do_get_time()
-{
-/* Get and return the current clock time in ticks. */
+PRIVATE void do_get_time(void) {
+    /* Get and return the current clock time in ticks. */
 
-  mc.m_type = REAL_TIME;	/* set message type for reply */
-  mc.NEW_TIME = boot_time + realtime/HZ;	/* current real time */
+    mc.m_type = REAL_TIME;                   /* set message type for reply */
+    mc.NEW_TIME = boot_time + realtime / HZ; /* current real time */
 }
-
 
 /*===========================================================================*
  *				do_set_time				     *
  *===========================================================================*/
-PRIVATE do_set_time(m_ptr)
-message *m_ptr;			/* pointer to request message */
-{
-/* Set the real time clock.  Only the superuser can use this call. */
+PRIVATE void do_set_time(message *m_ptr) {
+    /* Set the real time clock.  Only the superuser can use this call. */
 
-  boot_time = m_ptr->NEW_TIME - realtime/HZ;
+    boot_time = m_ptr->NEW_TIME - realtime / HZ;
 }
-
 
 /*===========================================================================*
  *				do_clocktick				     *
  *===========================================================================*/
-PRIVATE do_clocktick()
-{
-/* This routine called on every clock tick. */
+PRIVATE void do_clocktick(void) {
+    /* This routine called on every clock tick. */
 
-  register struct proc *rp;
-  register int t, proc_nr;
-  extern int pr_busy, pcount, cum_count, prev_ct;
+    register struct proc *rp;
+    register int t, proc_nr;
+    extern int pr_busy, pcount, cum_count, prev_ct;
 
-  /* To guard against race conditions, first copy 'lost_ticks' to a local
-   * variable, add this to 'realtime', and then subtract it from 'lost_ticks'.
-   */
-  t = lost_ticks;		/* 'lost_ticks' counts missed interrupts */
-  realtime += t + 1;		/* update the time of day */
-  lost_ticks -= t;		/* these interrupts are no longer missed */
+    /* To guard against race conditions, first copy 'lost_ticks' to a local
+     * variable, add this to 'realtime', and then subtract it from 'lost_ticks'.
+     */
+    t = lost_ticks;    /* 'lost_ticks' counts missed interrupts */
+    realtime += t + 1; /* update the time of day */
+    lost_ticks -= t;   /* these interrupts are no longer missed */
 
-  if (next_alarm <= realtime) {
-	/* An alarm may have gone off, but proc may have exited, so check. */
-	next_alarm = MAX_P_LONG;	/* start computing next alarm */
-	for (rp = &proc[0]; rp < &proc[NR_TASKS+NR_PROCS]; rp++) {
-		if (rp->p_alarm != (real_time) 0) {
-			/* See if this alarm time has been reached. */
-			if (rp->p_alarm <= realtime) {
-				/* A timer has gone off.  If it is a user proc,
-				 * send it a signal.  If it is a task, call the
-				 * function previously specified by the task.
-				 */
-				proc_nr = rp - proc - NR_TASKS;
-				if (proc_nr >= 0)
-					cause_sig(proc_nr, SIGALRM);
-				else
-					(*watch_dog[-proc_nr])();
-				rp->p_alarm = 0;
-			}
+    if (next_alarm <= realtime) {
+        /* An alarm may have gone off, but proc may have exited, so check. */
+        next_alarm = MAX_P_LONG; /* start computing next alarm */
+        for (rp = &proc[0]; rp < &proc[NR_TASKS + NR_PROCS]; rp++) {
+            if (rp->p_alarm != (real_time)0) {
+                /* See if this alarm time has been reached. */
+                if (rp->p_alarm <= realtime) {
+                    /* A timer has gone off.  If it is a user proc,
+                     * send it a signal.  If it is a task, call the
+                     * function previously specified by the task.
+                     */
+                    proc_nr = rp - proc - NR_TASKS;
+                    if (proc_nr >= 0)
+                        cause_sig(proc_nr, SIGALRM);
+                    else
+                        (*watch_dog[-proc_nr])();
+                    rp->p_alarm = 0;
+                }
 
-			/* Work on determining which alarm is next. */
-			if (rp->p_alarm != 0 && rp->p_alarm < next_alarm)
-				next_alarm = rp->p_alarm;
-		}
-	}
-  }
+                /* Work on determining which alarm is next. */
+                if (rp->p_alarm != 0 && rp->p_alarm < next_alarm)
+                    next_alarm = rp->p_alarm;
+            }
+        }
+    }
 
-  accounting();			/* keep track of who is using the cpu */
+    accounting(); /* keep track of who is using the cpu */
 
-  /* If a user process has been running too long, pick another one. */
-  if (--sched_ticks == 0) {
-	if (bill_ptr == prev_ptr) sched();	/* process has run too long */
-	sched_ticks = SCHED_RATE;		/* reset quantum */
-	prev_ptr = bill_ptr;			/* new previous process */
+    /* If a user process has been running too long, pick another one. */
+    if (--sched_ticks == 0) {
+        if (bill_ptr == prev_ptr)
+            sched();              /* process has run too long */
+        sched_ticks = SCHED_RATE; /* reset quantum */
+        prev_ptr = bill_ptr;      /* new previous process */
 
-	/* Check if printer is hung up, and if so, restart it. */
-	if (pr_busy && pcount > 0 && cum_count == prev_ct) pr_char(); 
-	prev_ct = cum_count;	/* record # characters printed so far */
-  }
-
+        /* Check if printer is hung up, and if so, restart it. */
+        if (pr_busy && pcount > 0 && cum_count == prev_ct)
+            pr_char();
+        prev_ct = cum_count; /* record # characters printed so far */
+    }
 }
 
 /*===========================================================================*
  *				accounting				     *
  *===========================================================================*/
-PRIVATE accounting()
-{
-/* Update user and system accounting times.  The variable 'bill_ptr' is always
- * kept pointing to the process to charge for CPU usage.  If the CPU was in
- * user code prior to this clock tick, charge the tick as user time, otherwise
- * charge it as system time.
- */
+PRIVATE void accounting(void) {
+    /* Update user and system accounting times.  The variable 'bill_ptr' is always
+     * kept pointing to the process to charge for CPU usage.  If the CPU was in
+     * user code prior to this clock tick, charge the tick as user time, otherwise
+     * charge it as system time.
+     */
 
-  if (prev_proc >= LOW_USER)
-	bill_ptr->user_time++;	/* charge CPU time */
-  else
-	bill_ptr->sys_time++;	/* charge system time */
+    if (prev_proc >= LOW_USER)
+        bill_ptr->user_time++; /* charge CPU time */
+    else
+        bill_ptr->sys_time++; /* charge system time */
 }
-
 
 /*===========================================================================*
  *				init_clock				     *
  *===========================================================================*/
-PRIVATE init_clock()
-{
-/* Initialize channel 2 of the 8253A timer to e.g. 60 Hz. */
+PRIVATE void init_clock(void) {
+    /* Initialize channel 2 of the 8253A timer to e.g. 60 Hz. */
 
-  unsigned int count, low_byte, high_byte;
+    unsigned int count, low_byte, high_byte;
 
-  count = (unsigned) (IBM_FREQ/HZ);	/* value to load into the timer */
-  low_byte = count & BYTE;		/* compute low-order byte */
-  high_byte = (count >> 8) & BYTE;	/* compute high-order byte */
-  port_out(TIMER_MODE, SQUARE_WAVE);	/* set timer to run continuously */
-  port_out(TIMER0, low_byte);		/* load timer low byte */
-  port_out(TIMER0, high_byte);		/* load timer high byte */
+    count = (unsigned)(IBM_FREQ / HZ); /* value to load into the timer */
+    low_byte = count & BYTE;           /* compute low-order byte */
+    high_byte = (count >> 8) & BYTE;   /* compute high-order byte */
+    port_out(TIMER_MODE, SQUARE_WAVE); /* set timer to run continuously */
+    port_out(TIMER0, low_byte);        /* load timer low byte */
+    port_out(TIMER0, high_byte);       /* load timer high byte */
 }

--- a/kernel/dmp.c
+++ b/kernel/dmp.c
@@ -1,134 +1,130 @@
 /* This file contains some dumping routines for debugging. */
 
-#include "../h/const.h"
-#include "../h/type.h"
 #include "../h/callnr.h"
 #include "../h/com.h"
+#include "../h/const.h"
 #include "../h/error.h"
+#include "../h/type.h"
 #include "const.h"
-#include "type.h"
 #include "glo.h"
+#include "type.h"
+
+/* Print a process name by index. */
+static void prname(int i);
 #include "proc.h"
 
 #define NSIZE 20
-phys_bytes aout[NR_PROCS];	/* pointers to the program names */
-char nbuff[NSIZE+1];
+phys_bytes aout[NR_PROCS]; /* pointers to the program names */
+char nbuff[NSIZE + 1];
 int vargv;
 
 /*===========================================================================*
- *				DEBUG routines here			     * 
+ *				DEBUG routines here			     *
  *===========================================================================*/
-p_dmp()
-{
-/* Proc table dump */
+p_dmp() {
+    /* Proc table dump */
 
-  register struct proc *rp;
-  char *np;
-  vir_bytes base, limit, first, last;
-  phys_bytes ltmp, dst;
-  int index;
-  extern phys_bytes umap();
+    register struct proc *rp;
+    char *np;
+    vir_bytes base, limit, first, last;
+    phys_bytes ltmp, dst;
+    int index;
+    extern phys_bytes umap();
 
-  printf(
-  "\nproc  -pid- -pc-  -sp-  flag  user  -sys-  base limit recv   command\n");
+    printf("\nproc  -pid- -pc-  -sp-  flag  user  -sys-  base limit recv   command\n");
 
-  dst = umap(proc_addr(SYSTASK), D, nbuff, NSIZE);
+    dst = umap(proc_addr(SYSTASK), D, nbuff, NSIZE);
 
-  for (rp = &proc[0]; rp < &proc[NR_PROCS+NR_TASKS]; rp++)  {
-	if (rp->p_flags & P_SLOT_FREE) continue;
-	first = rp->p_map[T].mem_phys;
-	last = rp->p_map[S].mem_phys + rp->p_map[S].mem_len;
-	ltmp = ((long) first << 4) + 512L;
-	base = (vir_bytes) (ltmp/1024L);
-	ltmp = (((long) last << 4) + 512L);
-	limit = (vir_bytes) (ltmp/1024L);
-	prname(rp - proc);
-	printf(" %4d %4x %4x %4x %6D %7D  %3dK %3dK  ",
-		rp->p_pid, rp->p_pcpsw.pc, rp->p_sp, rp->p_flags,
-		rp->user_time, rp->sys_time,
-		base, limit);
-		if (rp->p_flags == 0)
-			printf("      ");
-		else
-			prname(NR_TASKS + rp->p_getfrom);
+    for (rp = &proc[0]; rp < &proc[NR_PROCS + NR_TASKS]; rp++) {
+        if (rp->p_flags & P_SLOT_FREE)
+            continue;
+        first = rp->p_map[T].mem_phys;
+        last = rp->p_map[S].mem_phys + rp->p_map[S].mem_len;
+        ltmp = ((long)first << 4) + 512L;
+        base = (vir_bytes)(ltmp / 1024L);
+        ltmp = (((long)last << 4) + 512L);
+        limit = (vir_bytes)(ltmp / 1024L);
+        prname(rp - proc);
+        printf(" %4d %4x %4x %4x %6D %7D  %3dK %3dK  ", rp->p_pid, rp->p_pcpsw.pc, rp->p_sp,
+               rp->p_flags, rp->user_time, rp->sys_time, base, limit);
+        if (rp->p_flags == 0)
+            printf("      ");
+        else
+            prname(NR_TASKS + rp->p_getfrom);
 
-	/* Fetch the command string from the user process. */
-	index = rp - proc - NR_TASKS;
-	if (index > LOW_USER && aout[index] != 0) {
-		phys_copy(aout[index], dst, (long) NSIZE);
-		aout[NSIZE] = 0;
-		for (np = &nbuff[0]; np < &nbuff[NSIZE]; np++)
-			if (*np <= ' ' || *np >= 0177) *np = 0;
-		if (index == LOW_USER + 1)
-			printf("/bin/sh");
-		else
-			printf("%s", nbuff);
-	}
-	printf("\n");
-  }
-  printf("\n");
+        /* Fetch the command string from the user process. */
+        index = rp - proc - NR_TASKS;
+        if (index > LOW_USER && aout[index] != 0) {
+            phys_copy(aout[index], dst, (long)NSIZE);
+            aout[NSIZE] = 0;
+            for (np = &nbuff[0]; np < &nbuff[NSIZE]; np++)
+                if (*np <= ' ' || *np >= 0177)
+                    *np = 0;
+            if (index == LOW_USER + 1)
+                printf("/bin/sh");
+            else
+                printf("%s", nbuff);
+        }
+        printf("\n");
+    }
+    printf("\n");
 }
 
+map_dmp() {
+    register struct proc *rp;
+    vir_bytes base, limit, first, last;
+    phys_bytes ltmp;
 
-
-map_dmp()
-{
-  register struct proc *rp;
-  vir_bytes base, limit, first, last;
-  phys_bytes ltmp;
-
-  printf("\nPROC   -----TEXT-----  -----DATA-----  ----STACK-----  BASE SIZE\n");
-  for (rp = &proc[NR_TASKS]; rp < &proc[NR_TASKS+NR_PROCS]; rp++)  {
-	if (rp->p_flags & P_SLOT_FREE) continue;
-	first = rp->p_map[T].mem_phys;
-	last = rp->p_map[S].mem_phys + rp->p_map[S].mem_len;
-	ltmp = ((long) first << 4) + 512L;
-	base = (vir_bytes) (ltmp/1024L);
-	ltmp = (((long) (last-first) << 4) + 512L);
-	limit = (vir_bytes) (ltmp/1024L);
-	prname(rp-proc);
-	printf(" %4x %4x %4x  %4x %4x %4x  %4x %4x %4x  %3dK %3dK\n", 
-	    rp->p_map[T].mem_vir, rp->p_map[T].mem_phys, rp->p_map[T].mem_len,
-	    rp->p_map[D].mem_vir, rp->p_map[D].mem_phys, rp->p_map[D].mem_len,
-	    rp->p_map[S].mem_vir, rp->p_map[S].mem_phys, rp->p_map[S].mem_len,
-	    base, limit);
-  }
+    printf("\nPROC   -----TEXT-----  -----DATA-----  ----STACK-----  BASE SIZE\n");
+    for (rp = &proc[NR_TASKS]; rp < &proc[NR_TASKS + NR_PROCS]; rp++) {
+        if (rp->p_flags & P_SLOT_FREE)
+            continue;
+        first = rp->p_map[T].mem_phys;
+        last = rp->p_map[S].mem_phys + rp->p_map[S].mem_len;
+        ltmp = ((long)first << 4) + 512L;
+        base = (vir_bytes)(ltmp / 1024L);
+        ltmp = (((long)(last - first) << 4) + 512L);
+        limit = (vir_bytes)(ltmp / 1024L);
+        prname(rp - proc);
+        printf(" %4x %4x %4x  %4x %4x %4x  %4x %4x %4x  %3dK %3dK\n", rp->p_map[T].mem_vir,
+               rp->p_map[T].mem_phys, rp->p_map[T].mem_len, rp->p_map[D].mem_vir,
+               rp->p_map[D].mem_phys, rp->p_map[D].mem_len, rp->p_map[S].mem_vir,
+               rp->p_map[S].mem_phys, rp->p_map[S].mem_len, base, limit);
+    }
 }
 
-
-char *nayme[]= {"PRINTR", "TTY   ", "WINCHE", "FLOPPY", "RAMDSK", "CLOCK ", 
-		"SYS   ", "HARDWR", "MM    ", "FS    ", "INIT  "};
+char *nayme[] = {"PRINTR", "TTY   ", "WINCHE", "FLOPPY", "RAMDSK", "CLOCK ",
+                 "SYS   ", "HARDWR", "MM    ", "FS    ", "INIT  "};
 /* Print process name by index */
-static void prname(int i)
-{
-  if (i == ANY+NR_TASKS)
-	printf("ANY   ");
-  else if (i >= 0 && i <= NR_TASKS+2)
-	printf("%s",nayme[i]);
-  else
-	printf("%4d  ", i-NR_TASKS);
+static void prname(int i) {
+    if (i == ANY + NR_TASKS)
+        printf("ANY   ");
+    else if (i >= 0 && i <= NR_TASKS + 2)
+        printf("%s", nayme[i]);
+    else
+        printf("%4d  ", i - NR_TASKS);
 }
 
 /* Store command name for dumping */
-static void set_name(int proc_nr, char *ptr)
-{
-/* When an EXEC call is done, the kernel is told about the stack pointer.
- * It uses the stack pointer to find the command line, for dumping
- * purposes.
- */
+static void set_name(int proc_nr, char *ptr) {
+    /* When an EXEC call is done, the kernel is told about the stack pointer.
+     * It uses the stack pointer to find the command line, for dumping
+     * purposes.
+     */
 
-  extern phys_bytes umap();
-  phys_bytes src, dst, count;
+    extern phys_bytes umap();
+    phys_bytes src, dst, count;
 
-  if (ptr == (char *) 0) {
-	aout[proc_nr] = (phys_bytes) 0;
-	return;
-  }
+    if (ptr == (char *)0) {
+        aout[proc_nr] = (phys_bytes)0;
+        return;
+    }
 
-  src = umap(proc_addr(proc_nr), D, ptr + 2, 2);
-  if (src == 0) return;
-  dst = umap(proc_addr(SYSTASK), D, &vargv, 2);
-  phys_copy(src, dst, 2L);
+    src = umap(proc_addr(proc_nr), D, ptr + 2, 2);
+    if (src == 0)
+        return;
+    dst = umap(proc_addr(SYSTASK), D, &vargv, 2);
+    phys_copy(src, dst, 2L);
 
-  aout[proc_nr] = umap(proc_addr(proc_nr), D, vargv, NSIZE);
+    aout[proc_nr] = umap(proc_addr(proc_nr), D, vargv, NSIZE);
 }

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -4,47 +4,49 @@
  * It contains the process' registers, memory map, accounting, and message
  * send/receive information.
  */
+#include "type.h"
+#include <stdint.h>
 
 EXTERN struct proc {
-  uint64_t p_reg[NR_REGS];      /* process' registers */
-  uint64_t p_sp;                /* stack pointer */
-  struct pc_psw p_pcpsw;        /* pc and psw as pushed by interrupt */
-  int p_flags;                  /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
-  struct mem_map p_map[NR_SEGS];/* memory map */
-  uint64_t p_splimit;           /* lowest legal stack value */
-  int p_pid;                    /* process id passed in from MM */
+    uint64_t p_reg[NR_REGS];       /* process' registers */
+    uint64_t p_sp;                 /* stack pointer */
+    struct pc_psw p_pcpsw;         /* pc and psw as pushed by interrupt */
+    int p_flags;                   /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
+    struct mem_map p_map[NR_SEGS]; /* memory map */
+    uint64_t p_splimit;            /* lowest legal stack value */
+    int p_pid;                     /* process id passed in from MM */
 
-  real_time user_time;          /* user time in ticks */
-  real_time sys_time;           /* sys time in ticks */
-  real_time child_utime;        /* cumulative user time of children */
-  real_time child_stime;        /* cumulative sys time of children */
-  real_time p_alarm;            /* time of next alarm in ticks, or 0 */
+    real_time user_time;   /* user time in ticks */
+    real_time sys_time;    /* sys time in ticks */
+    real_time child_utime; /* cumulative user time of children */
+    real_time child_stime; /* cumulative sys time of children */
+    real_time p_alarm;     /* time of next alarm in ticks, or 0 */
 
-  struct proc *p_callerq;       /* head of list of procs wishing to send */
-  struct proc *p_sendlink;      /* link to next proc wishing to send */
-  message *p_messbuf;           /* pointer to message buffer */
-  int p_getfrom;                /* from whom does process want to receive? */
+    struct proc *p_callerq;  /* head of list of procs wishing to send */
+    struct proc *p_sendlink; /* link to next proc wishing to send */
+    message *p_messbuf;      /* pointer to message buffer */
+    int p_getfrom;           /* from whom does process want to receive? */
 
-  struct proc *p_nextready;     /* pointer to next ready process */
-  int p_pending;                /* bit map for pending signals 1-16 */
-  uint64_t cr3;                 /* page table base */
-  int p_priority;               /* scheduling priority */
-  int p_cpu;                    /* CPU affinity */
-} proc[NR_TASKS+NR_PROCS];
+    struct proc *p_nextready; /* pointer to next ready process */
+    int p_pending;            /* bit map for pending signals 1-16 */
+    uint64_t cr3;             /* page table base */
+    int p_priority;           /* scheduling priority */
+    int p_cpu;                /* CPU affinity */
+} proc[NR_TASKS + NR_PROCS];
 
 /* Bits for p_flags in proc[].  A process is runnable iff p_flags == 0 */
-#define P_SLOT_FREE      001    /* set when slot is not in use */
-#define NO_MAP           002    /* keeps unmapped forked child from running */
-#define SENDING          004    /* set when process blocked trying to send */
-#define RECEIVING        010    /* set when process blocked trying to recv */
+#define P_SLOT_FREE 001 /* set when slot is not in use */
+#define NO_MAP 002      /* keeps unmapped forked child from running */
+#define SENDING 004     /* set when process blocked trying to send */
+#define RECEIVING 010   /* set when process blocked trying to recv */
 
 #define proc_addr(n) &proc[NR_TASKS + n]
-#define NIL_PROC (struct proc *) 0
+#define NIL_PROC (struct proc *)0
 
-EXTERN struct proc *proc_ptr;   /* &proc[cur_proc] */
-EXTERN struct proc *bill_ptr;   /* ptr to process to bill for clock ticks */
+EXTERN struct proc *proc_ptr;                        /* &proc[cur_proc] */
+EXTERN struct proc *bill_ptr;                        /* ptr to process to bill for clock ticks */
 EXTERN struct proc *rdy_head[NR_CPUS][SCHED_QUEUES]; /* per-CPU ready list heads */
 EXTERN struct proc *rdy_tail[NR_CPUS][SCHED_QUEUES]; /* per-CPU ready list tails */
 
-EXTERN unsigned busy_map;               /* bit map of busy tasks */
-EXTERN message *task_mess[NR_TASKS+1];  /* ptrs to messages for busy tasks */
+EXTERN unsigned busy_map;                /* bit map of busy tasks */
+EXTERN message *task_mess[NR_TASKS + 1]; /* ptrs to messages for busy tasks */

--- a/kernel/type.h
+++ b/kernel/type.h
@@ -1,3 +1,6 @@
+#ifndef KERNEL_TYPE_H
+#define KERNEL_TYPE_H
+
 /* The 'pc_psw' struct is machine dependent.  It must contain the information
  * pushed onto the stack by an interrupt, in the same format as the hardware
  * creates and expects.  It is used for storing the interrupt status after a
@@ -6,11 +9,13 @@
 
 #include <stdint.h>
 struct pc_psw {
-  uint64_t rip;                 /* instruction pointer */
-  uint64_t rflags;              /* rflags register */
+    uint64_t pc;  /* program counter */
+    uint64_t psw; /* processor status word */
 };
 
 struct sig_info {
-  int signo;
-  struct pc_psw sigpcpsw;
+    int signo;
+    struct pc_psw sigpcpsw;
 };
+
+#endif /* KERNEL_TYPE_H */

--- a/lib/fclose.c
+++ b/lib/fclose.c
@@ -1,23 +1,24 @@
-#include "../include/stdio.h"
 #include "../include/lib.h"
+#include "../include/stdio.h"
 
-fclose(fp)
-FILE *fp;
-{
-	register int i;
+/*
+ * Close a stream and release its resources.
+ */
+int fclose(FILE *fp) {
+    int i; /* index within _io_table */
 
-	for (i=0; i<NFILES; i++)
-		if (fp == _io_table[i]) {
-			_io_table[i] = 0;
-			break;
-		}
-	if (i >= NFILES)
-		return(EOF);
-	fflush(fp);
-	close(fp->_fd);
-        if ( testflag(fp,IOMYBUF) && fp->_buf )
-                safe_free( fp->_buf );
-        safe_free(fp);
-	return(NULL);
+    for (i = 0; i < NFILES; i++) {
+        if (fp == _io_table[i]) {
+            _io_table[i] = 0;
+            break;
+        }
+    }
+    if (i >= NFILES)
+        return EOF;
+    fflush(fp);
+    close(fp->_fd);
+    if (testflag(fp, IOMYBUF) && fp->_buf)
+        safe_free(fp->_buf);
+    safe_free(fp);
+    return 0;
 }
-

--- a/lib/minix/setjmp.c
+++ b/lib/minix/setjmp.c
@@ -1,21 +1,18 @@
-#include <setjmp.h>
-#include <stdlib.h>
-#include "../../include/lib.h"
 #include "../../include/setjmp.h"
+#include "../../include/lib.h"
+#include <stdlib.h>
 
 /*
  * Alternate location for _setjmp/_longjmp used by certain Minix binaries.
  * Implementation identical to the generic versions.
  */
-PUBLIC int _setjmp(jmp_buf env)
-{
+PUBLIC int _setjmp(jmp_buf env) {
     jmp_buf *real = safe_malloc(sizeof(jmp_buf));
     *(jmp_buf **)env = real;
     return setjmp(*real);
 }
 
-PUBLIC void _longjmp(jmp_buf env, int val)
-{
+PUBLIC void _longjmp(jmp_buf env, int val) {
     jmp_buf *real = *(jmp_buf **)env;
     if (val == 0) {
         val = 1;

--- a/lib/perror.c
+++ b/lib/perror.c
@@ -1,36 +1,98 @@
 /* perror(s) print the current error message. */
 
 #include "../h/error.h"
+#include <unistd.h>
+
 extern int errno;
-char *error_message[NERROR+1] = {
-        "Error 0",
-        "Not owner",
-        "No such file or directory",
-        "No such process",
-        "Interrupted system call",
-        "I/O error",
-        "No such device or address",
-        "Arg list too long",
-        "Exec format error",
-        "Bad file number",
-        "No children",
-        "No more processes",
-        "Not enough core",
-        "Permission denied",
-        "Bad address",
-        "Block device required",
-        "Mount device busy",
-        "File exists",
-        "Cross-device link",
-        "No such device",
-        "Not a directory",
-        "Is a directory",
-        "Invalid argument",
-        "File table overflow",
-        "Too many open files",
-        "Not a typewriter",
-        "Text file busy",
-        "File too large",
+static int slen(const char *s);
+
+char *error_message[NERROR + 1] = {"Error 0",
+
+                                   "Not owner",
+
+                                   "No such file or directory",
+
+                                   "No such process",
+
+                                   "Interrupted system call",
+
+                                   "I/O error",
+
+                                   "No such device or address",
+
+                                   "Arg list too long",
+
+                                   "Exec format error",
+
+                                   "Bad file number",
+
+                                   "No children",
+
+                                   "No more processes",
+
+                                   "Not enough core",
+
+                                   "Permission denied",
+
+                                   "Bad address",
+
+                                   "Block device required",
+
+                                   "Mount device busy",
+
+                                   "File exists",
+
+                                   "Cross-device link",
+
+                                   "No such device",
+
+                                   "Not a directory",
+
+                                   "Is a directory",
+
+                                   "Invalid argument",
+
+                                   "File table overflow",
+
+                                   "Too many open files",
+
+                                   "Not a typewriter",
+
+                                   "Text file busy",
+
+                                   "File too large",
+
+                                   "No space left on device",
+
+                                   "Illegal seek",
+
+                                   "Read-only file system",
+
+                                   "Too many links",
+
+                                   "Broken pipe",
+
+                                   "Math argument",
+
+                                   "Result too large"
+
+};
+
+void perror(const char *s) {
+    if (errno < 0 || errno > NERROR) {
+        write(2, "Invalid errno\n", 14);
+    } else {
+        write(2, s, slen(s));
+        write(2, ": ", 2);
+        write(2, error_message[errno], slen(error_message[errno]));
+        write(2, "\n", 1);
+    }
+}
+static int slen(const char *s) {
+    int k = 0;
+    while (*s++)
+        k++;
+    return k;
         "No space left on device",
         "Illegal seek",
         "Read-only file system",

--- a/lib/printk.c
+++ b/lib/printk.c
@@ -4,93 +4,143 @@
  * has been defined as printk there.
  */
 
+#define MAXDIGITS 12
 
-#define MAXDIGITS         12
+static int bintoascii(long num, int radix, char a[MAXDIGITS]);
 
-printk(s, arglist)
-char *s;
-int *arglist;
-{
-  int w, k, r, *valp;
-  unsigned u;
-  long l, *lp;
-  char a[MAXDIGITS], *p, *p1, c;
+void printk(char *s, int *arglist) {
+    int w, k, r, *valp;
+    unsigned u;
+    long l, *lp;
+    char a[MAXDIGITS], *p, *p1, c;
 
-  valp = (int *)  &arglist;
-  while (*s != '\0') {
-	if (*s !=  '%') {
-		putc(*s++);
-		continue;
-	}
+    valp = (int *)&arglist;
+    while (*s != '\0') {
+        if (*s != '%') {
+            putc(*s++);
+            continue;
+        }
 
-	w = 0;
-	s++;
-	while (*s >= '0' && *s <= '9') {
-		w = 10 * w + (*s - '0');
-		s++;
-	}
+        w = 0;
+        s++;
+        while (*s >= '0' && *s <= '9') {
+            w = 10 * w + (*s - '0');
+            s++;
+        }
 
-	lp = (long *) valp;
+        lp = (long *)valp;
 
-	switch(*s) {
-	    case 'd':	k = *valp++; l = k;  r = 10;  break;
-	    case 'o':	k = *valp++; u = k; l = u;  r = 8;  break;
-	    case 'x':	k = *valp++; u = k; l = u;  r = 16;  break;
-	    case 'D':	l = *lp++;  r = 10; valp = (int *) lp; break;
-	    case 'O':	l = *lp++;  r = 8;  valp = (int *) lp; break;
-	    case 'X':	l = *lp++;  r = 16; valp = (int *) lp; break;
-	    case 'c':	k = *valp++; putc(k); s++; continue;
-	    case 's':	p = (char *) *valp++; 
-			p1 = p;
-			while(c = *p++) putc(c); s++;
-			if ( (k = w - (p-p1-1)) > 0) while (k--) putc(' ');
-			continue;
-	    default:	putc('%'); putc(*s++); continue;
-	}
+        switch (*s) {
+        case 'd':
+            k = *valp++;
+            l = k;
+            r = 10;
+            break;
+        case 'o':
+            k = *valp++;
+            u = k;
+            l = u;
+            r = 8;
+            break;
+        case 'x':
+            k = *valp++;
+            u = k;
+            l = u;
+            r = 16;
+            break;
+        case 'D':
+            l = *lp++;
+            r = 10;
+            valp = (int *)lp;
+            break;
+        case 'O':
+            l = *lp++;
+            r = 8;
+            valp = (int *)lp;
+            break;
+        case 'X':
+            l = *lp++;
+            r = 16;
+            valp = (int *)lp;
+            break;
+        case 'c':
+            k = *valp++;
+            putc(k);
+            s++;
+            continue;
+        case 's':
+            p = (char *)*valp++;
+            p1 = p;
+            while ((c = *p++) != '\0')
+                putc(c);
+            s++;
+            if ((k = w - (p - p1 - 1)) > 0)
+                while (k--)
+                    putc(' ');
+            continue;
+        default:
+            putc('%');
+            putc(*s++);
+            continue;
+        }
 
-	k = bintoascii(l, r, a);
-	if ( (r = w - k) > 0) while(r--) putc(' ');
-	for (r = k - 1; r >= 0; r--) putc(a[r]);
-	s++;
-  }
+        k = bintoascii(l, r, a);
+        if ((r = w - k) > 0)
+            while (r--)
+                putc(' ');
+        for (r = k - 1; r >= 0; r--)
+            putc(a[r]);
+        s++;
+    }
 }
 
+static int bintoascii(long num, int radix, char a[MAXDIGITS]) {
 
+    int i, n, hit, negative;
 
-static int bintoascii(num, radix, a)
-long num;
-int radix;
-char a[MAXDIGITS];
-{
+    negative = 0;
+    if (num == 0) {
+        a[0] = '0';
+        return (1);
+    }
+    if (num < 0 && radix == 10) {
+        num = -num;
+        negative++;
+    }
+    for (n = 0; n < MAXDIGITS; n++)
+        a[n] = 0;
+    n = 0;
 
-  int i, n, hit, negative;
+    do {
+        if (radix == 10) {
+            a[n] = num % 10;
+            num = (num - a[n]) / 10;
+        }
+        if (radix == 8) {
+            a[n] = num & 0x7;
+            num = (num >> 3) & 0x1FFFFFFF;
+        }
+        if (radix == 16) {
+            a[n] = num & 0xF;
+            num = (num >> 4) & 0x0FFFFFFF;
+        }
+        n++;
+    } while (num != 0);
 
-  negative = 0;
-  if (num == 0) {a[0] = '0'; return(1);}
-  if (num < 0 && radix == 10) {num = -num; negative++;}
-  for (n = 0; n < MAXDIGITS; n++) a[n] = 0;
-  n = 0;
-
-  do {
-	if (radix == 10) {a[n] = num % 10; num = (num -a[n])/10;}
-	if (radix ==  8) {a[n] = num & 0x7;  num = (num >> 3) & 0x1FFFFFFF;}
-	if (radix == 16) {a[n] = num & 0xF;  num = (num >> 4) & 0x0FFFFFFF;}
-	n++;
-  } while (num != 0);
-
-  /* Convert to ASCII. */
-  hit = 0;
-  for (i = n - 1; i >= 0; i--) {
-	if (a[i] == 0 && hit == 0) {
-		a[i] = ' ';
-	} else {
-		if (a[i] < 10)
-			a[i] += '0';
-		else
-			a[i] += 'A' - 10;
-		hit++;
-	}
-  }
-  if (negative) a[n++] = '-';
-  return(n);
+    /* Convert to ASCII. */
+    hit = 0;
+    for (i = n - 1; i >= 0; i--) {
+        if (a[i] == 0 && hit == 0) {
+            a[i] = ' ';
+        } else {
+            if (a[i] < 10)
+                a[i] += '0';
+            else
+                a[i] += 'A' - 10;
+            hit++;
+        }
+    }
+    if (negative)
+        a[n++] = '-';
+    return (n);
 }

--- a/lib/prints.c
+++ b/lib/prints.c
@@ -5,52 +5,59 @@
  * small utilities do not need numeric printing, they all use prints.
  */
 
-
 #define TRUNC_SIZE 128
 char Buf[TRUNC_SIZE], *Bufp;
 
+static void put(char c);
+
 #define OUT 1
 
-prints(s, arglist)
-register char *s;
-int *arglist;
-{
-  register w;
-  int k, r, *valp;
-  char *p, *p1, c;
+void prints(char *s, int *arglist) {
+    int w;
+    int k, r, *valp;
+    char *p, *p1, c;
 
-  Bufp = Buf;
-  valp = (int *)  &arglist;
-  while (*s != '\0') {
-	if (*s !=  '%') {
-		put(*s++);
-		continue;
-	}
+    Bufp = Buf;
+    valp = (int *)&arglist;
+    while (*s != '\0') {
+        if (*s != '%') {
+            put(*s++);
+            continue;
+        }
 
-	w = 0;
-	s++;
-	while (*s >= '0' && *s <= '9') {
-		w = 10 * w + (*s - '0');
-		s++;
-	}
+        w = 0;
+        s++;
+        while (*s >= '0' && *s <= '9') {
+            w = 10 * w + (*s - '0');
+            s++;
+        }
 
-
-	switch(*s) {
-	    case 'c':	k = *valp++; put(k); s++; continue;
-	    case 's':	p = (char *) *valp++; 
-			p1 = p;
-			while(c = *p++) put(c); s++;
-			if ( (k = w - (p-p1-1)) > 0) while (k--) put(' ');
-			continue;
-	    default:	put('%'); put(*s++); continue;
-	}
-
-  }
-  write(OUT, Buf, Bufp - Buf);	/* write everything in one blow. */
+        switch (*s) {
+        case 'c':
+            k = *valp++;
+            put(k);
+            s++;
+            continue;
+        case 's':
+            p = (char *)*valp++;
+            p1 = p;
+            while ((c = *p++) != '\0')
+                put(c);
+            s++;
+            if ((k = w - (p - p1 - 1)) > 0)
+                while (k--)
+                    put(' ');
+            continue;
+        default:
+            put('%');
+            put(*s++);
+            continue;
+        }
+    }
+    write(OUT, Buf, Bufp - Buf); /* write everything in one blow. */
 }
 
-static put(c)
-char c;
-{
-if (Bufp < &Buf[TRUNC_SIZE]) *Bufp++ = c;
+static void put(char c) {
+    if (Bufp < &Buf[TRUNC_SIZE])
+        *Bufp++ = c;
 }

--- a/lib/regexp.c
+++ b/lib/regexp.c
@@ -26,15 +26,17 @@
  *	Andy Tanenbaum also made some changes.
  */
 
-#include "../include/stdio.h"
 #include "../include/regexp.h"
 #include "../include/lib.h"
+#include "../include/stdio.h"
+#include <string.h>
+#include <strings.h>
 
 /*
  * The first byte of the regexp internal "program" is actually this magic
  * number; the start node begins in the second byte.
  */
-#define	MAGIC	0234
+#define MAGIC 0234
 
 /*
  * The "internal use only" fields in regexp.h are present to pass info from
@@ -73,21 +75,21 @@
  */
 
 /* definition	number	opnd?	meaning */
-#define	END	0	/* no	End of program. */
-#define	BOL	1	/* no	Match "" at beginning of line. */
-#define	EOL	2	/* no	Match "" at end of line. */
-#define	ANY	3	/* no	Match any one character. */
-#define	ANYOF	4	/* str	Match any character in this string. */
-#define	ANYBUT	5	/* str	Match any character not in this string. */
-#define	BRANCH	6	/* node	Match this alternative, or the next... */
-#define	BACK	7	/* no	Match "", "next" ptr points backward. */
-#define	EXACTLY	8	/* str	Match this string. */
-#define	NOTHING	9	/* no	Match empty string. */
-#define	STAR	10	/* node	Match this (simple) thing 0 or more times. */
-#define	PLUS	11	/* node	Match this (simple) thing 1 or more times. */
-#define	OPEN	20	/* no	Mark this point in input as start of #n. */
-		/*	OPEN+1 is number 1, etc. */
-#define	CLOSE	30	/* no	Analogous to OPEN. */
+#define END 0     /* no	End of program. */
+#define BOL 1     /* no	Match "" at beginning of line. */
+#define EOL 2     /* no	Match "" at end of line. */
+#define ANY 3     /* no	Match any one character. */
+#define ANYOF 4   /* str	Match any character in this string. */
+#define ANYBUT 5  /* str	Match any character not in this string. */
+#define BRANCH 6  /* node	Match this alternative, or the next... */
+#define BACK 7    /* no	Match "", "next" ptr points backward. */
+#define EXACTLY 8 /* str	Match this string. */
+#define NOTHING 9 /* no	Match empty string. */
+#define STAR 10   /* node	Match this (simple) thing 0 or more times. */
+#define PLUS 11   /* node	Match this (simple) thing 1 or more times. */
+#define OPEN 20   /* no	Mark this point in input as start of #n. */
+                  /*	OPEN+1 is number 1, etc. */
+#define CLOSE 30  /* no	Analogous to OPEN. */
 
 /*
  * Opcode notes:
@@ -121,47 +123,49 @@
  * Using two bytes for the "next" pointer is vast overkill for most things,
  * but allows patterns to get big without disasters.
  */
-#define	OP(p)	(*(p))
-#define	NEXT(p)	(((*((p)+1)&0377)<<8) + *((p)+2)&0377)
-#define	OPERAND(p)	((p) + 3)
-
-
+#define OP(p) (*(p))
+#define NEXT(p) (((*((p) + 1) & 0377) << 8) + *((p) + 2) & 0377)
+#define OPERAND(p) ((p) + 3)
 
 /*
  * Utility definitions.
  */
 #ifndef CHARBITS
-#define	UCHARAT(p)	((int)*(unsigned char *)(p))
+#define UCHARAT(p) ((int)*(unsigned char *)(p))
 #else
-#define	UCHARAT(p)	((int)*(p)&CHARBITS)
+#define UCHARAT(p) ((int)*(p) & CHARBITS)
 #endif
 
-#define	FAIL(m)	{ regerror(m); return(NULL); }
-#define	ISMULT(c)	((c) == '*' || (c) == '+' || (c) == '?')
-#define	META	"^$.[()|?+*\\"
+#define FAIL(m)                                                                                    \
+    {                                                                                              \
+        regerror(m);                                                                               \
+        return (NULL);                                                                             \
+    }
+#define ISMULT(c) ((c) == '*' || (c) == '+' || (c) == '?')
+#define META "^$.[()|?+*\\"
 
 /*
  * Flags to be passed up and down.
  */
-#define	HASWIDTH	01	/* Known never to match null string. */
-#define	SIMPLE		02	/* Simple enough to be STAR/PLUS operand. */
-#define	SPSTART		04	/* Starts with * or +. */
-#define	WORST		0	/* Worst case. */
+#define HASWIDTH 01 /* Known never to match null string. */
+#define SIMPLE 02   /* Simple enough to be STAR/PLUS operand. */
+#define SPSTART 04  /* Starts with * or +. */
+#define WORST 0     /* Worst case. */
 
 /*
  * Global work variables for regcomp().
  */
-static char *regparse;		/* Input-scan pointer. */
-static int regnpar;		/* () count. */
+static char *regparse; /* Input-scan pointer. */
+static int regnpar;    /* () count. */
 static char regdummy;
-static char *regcode;		/* Code-emit pointer; &regdummy = don't. */
-static long regsize;		/* Code size. */
+static char *regcode; /* Code-emit pointer; &regdummy = don't. */
+static long regsize;  /* Code size. */
 
 /*
  * Forward declarations for regcomp()'s friends.
  */
 #ifndef STATIC
-#define	STATIC	static
+#define STATIC static
 #endif
 STATIC char *reg();
 STATIC char *regbranch();
@@ -173,7 +177,7 @@ STATIC void regc();
 STATIC void reginsert();
 STATIC void regtail();
 STATIC void regoptail();
-STATIC int strcspn();
+STATIC int mystrcspn();
 
 /*
  - regcomp - compile a regular expression into internal code
@@ -190,80 +194,79 @@ STATIC int strcspn();
  * Beware that the optimization-preparation code in here knows about some
  * of the structure of the compiled regexp.
  */
-regexp *
-regcomp(exp)
+regexp *regcomp(exp)
 char *exp;
 {
-  register regexp *r;
-  register char *scan;
-  register char *longest;
-  register int len;
-  int flags;
+    register regexp *r;
+    register char *scan;
+    register char *longest;
+    register int len;
+    int flags;
 
-  if (exp == NULL)
-	FAIL("NULL argument");
+    if (exp == NULL)
+        FAIL("NULL argument");
 
-  /* First pass: determine size, legality. */
-  regparse = exp;
-  regnpar = 1;
-  regsize = 0L;
-  regcode = &regdummy;
-  regc(MAGIC);
-  if (reg(0, &flags) == NULL)
-	return(NULL);
+    /* First pass: determine size, legality. */
+    regparse = exp;
+    regnpar = 1;
+    regsize = 0L;
+    regcode = &regdummy;
+    regc(MAGIC);
+    if (reg(0, &flags) == NULL)
+        return (NULL);
 
-  /* Small enough for pointer-storage convention? */
-  if (regsize >= 32767L)		/* Probably could be 65535L. */
-	FAIL("regexp too big");
+    /* Small enough for pointer-storage convention? */
+    if (regsize >= 32767L) /* Probably could be 65535L. */
+        FAIL("regexp too big");
 
-  /* Allocate space. */
-  r = (regexp *)safe_malloc(sizeof(regexp) + (unsigned)regsize);
+    /* Allocate space. */
+    r = (regexp *)safe_malloc(sizeof(regexp) + (unsigned)regsize);
 
-  /* Second pass: emit code. */
-  regparse = exp;
-  regnpar = 1;
-  regcode = r->program;
-  regc(MAGIC);
-  if (reg(0, &flags) == NULL)
-	return(NULL);
+    /* Second pass: emit code. */
+    regparse = exp;
+    regnpar = 1;
+    regcode = r->program;
+    regc(MAGIC);
+    if (reg(0, &flags) == NULL)
+        return (NULL);
 
-  /* Dig out information for optimizations. */
-  r->regstart = '\0';	/* Worst-case defaults. */
-  r->reganch = 0;
-  r->regmust = NULL;
-  r->regmlen = 0;
-  scan = r->program+1;			/* First BRANCH. */
-  if (OP(regnext(scan)) == END) {		/* Only one top-level choice. */
-	scan = OPERAND(scan);
+    /* Dig out information for optimizations. */
+    r->regstart = '\0'; /* Worst-case defaults. */
+    r->reganch = 0;
+    r->regmust = NULL;
+    r->regmlen = 0;
+    scan = r->program + 1;          /* First BRANCH. */
+    if (OP(regnext(scan)) == END) { /* Only one top-level choice. */
+        scan = OPERAND(scan);
 
-	/* Starting-point info. */
-	if (OP(scan) == EXACTLY)
-		r->regstart = *OPERAND(scan);
-	else if (OP(scan) == BOL)
-		r->reganch++;
+        /* Starting-point info. */
+        if (OP(scan) == EXACTLY)
+            r->regstart = *OPERAND(scan);
+        else if (OP(scan) == BOL)
+            r->reganch++;
 
-	/*
-	 * If there's something expensive in the r.e., find the
-	 * longest literal string that must appear and make it the
-	 * regmust.  Resolve ties in favor of later strings, since
-	 * the regstart check works with the beginning of the r.e.
-	 * and avoiding duplication strengthens checking.  Not a
-	 * strong reason, but sufficient in the absence of others.
-	 */
-	if (flags&SPSTART) {
-		longest = NULL;
-		len = 0;
-		for (; scan != NULL; scan = regnext(scan))
-			if (OP(scan) == EXACTLY && strlen(OPERAND(scan)) >= len) {
-				longest = OPERAND(scan);
-				len = strlen(OPERAND(scan));
-			}
-		r->regmust = longest;
-		r->regmlen = len;
-	}
-  }
+        /*
+         * If there's something expensive in the r.e., find the
+         * longest literal string that must appear and make it the
+         * regmust.  Resolve ties in favor of later strings, since
+         * the regstart check works with the beginning of the r.e.
+         * and avoiding duplication strengthens checking.  Not a
+         * strong reason, but sufficient in the absence of others.
+         */
+        if (flags & SPSTART) {
+            longest = NULL;
+            len = 0;
+            for (; scan != NULL; scan = regnext(scan))
+                if (OP(scan) == EXACTLY && strlen(OPERAND(scan)) >= len) {
+                    longest = OPERAND(scan);
+                    len = strlen(OPERAND(scan));
+                }
+            r->regmust = longest;
+            r->regmlen = len;
+        }
+    }
 
-  return(r);
+    return (r);
 }
 
 /*
@@ -275,71 +278,70 @@ char *exp;
  * is a trifle forced, but the need to tie the tails of the branches to what
  * follows makes it hard to avoid.
  */
-static char *
-reg(paren, flagp)
-int paren;			/* Parenthesized? */
+static char *reg(paren, flagp)
+int paren; /* Parenthesized? */
 int *flagp;
 {
-  register char *ret;
-  register char *br;
-  register char *ender;
-  register int parno;
-  int flags;
+    register char *ret;
+    register char *br;
+    register char *ender;
+    register int parno;
+    int flags;
 
-  *flagp = HASWIDTH;	/* Tentatively. */
+    *flagp = HASWIDTH; /* Tentatively. */
 
-  /* Make an OPEN node, if parenthesized. */
-  if (paren) {
-	if (regnpar >= NSUBEXP)
-		FAIL("too many ()");
-	parno = regnpar;
-	regnpar++;
-	ret = regnode(OPEN+parno);
-  } else
-	ret = NULL;
+    /* Make an OPEN node, if parenthesized. */
+    if (paren) {
+        if (regnpar >= NSUBEXP)
+            FAIL("too many ()");
+        parno = regnpar;
+        regnpar++;
+        ret = regnode(OPEN + parno);
+    } else
+        ret = NULL;
 
-  /* Pick up the branches, linking them together. */
-  br = regbranch(&flags);
-  if (br == NULL)
-	return(NULL);
-  if (ret != NULL)
-	regtail(ret, br);	/* OPEN -> first. */
-  else
-	ret = br;
-  if (!(flags&HASWIDTH))
-	*flagp &= ~HASWIDTH;
-  *flagp |= flags&SPSTART;
-  while (*regparse == '|') {
-	regparse++;
-	br = regbranch(&flags);
-	if (br == NULL)
-		return(NULL);
-	regtail(ret, br);	/* BRANCH -> BRANCH. */
-	if (!(flags&HASWIDTH))
-		*flagp &= ~HASWIDTH;
-	*flagp |= flags&SPSTART;
-  }
+    /* Pick up the branches, linking them together. */
+    br = regbranch(&flags);
+    if (br == NULL)
+        return (NULL);
+    if (ret != NULL)
+        regtail(ret, br); /* OPEN -> first. */
+    else
+        ret = br;
+    if (!(flags & HASWIDTH))
+        *flagp &= ~HASWIDTH;
+    *flagp |= flags & SPSTART;
+    while (*regparse == '|') {
+        regparse++;
+        br = regbranch(&flags);
+        if (br == NULL)
+            return (NULL);
+        regtail(ret, br); /* BRANCH -> BRANCH. */
+        if (!(flags & HASWIDTH))
+            *flagp &= ~HASWIDTH;
+        *flagp |= flags & SPSTART;
+    }
 
-  /* Make a closing node, and hook it on the end. */
-  ender = regnode((paren) ? CLOSE+parno : END);	
-  regtail(ret, ender);
+    /* Make a closing node, and hook it on the end. */
+    ender = regnode((paren) ? CLOSE + parno : END);
+    regtail(ret, ender);
 
-  /* Hook the tails of the branches to the closing node. */
-  for (br = ret; br != NULL; br = regnext(br))
-	regoptail(br, ender);
+    /* Hook the tails of the branches to the closing node. */
+    for (br = ret; br != NULL; br = regnext(br))
+        regoptail(br, ender);
 
-  /* Check for proper termination. */
-  if (paren && *regparse++ != ')') {
-	FAIL("unmatched ()");
-  } else if (!paren && *regparse != '\0') {
-	if (*regparse == ')') {
-		FAIL("unmatched ()");
-	} else
-		FAIL("junk on end");	/* "Can't happen". */
-	/* NOTREACHED */
-  }
+    /* Check for proper termination. */
+    if (paren && *regparse++ != ')') {
+        FAIL("unmatched ()");
+    } else if (!paren && *regparse != '\0') {
+        if (*regparse == ')') {
+            FAIL("unmatched ()");
+        } else
+            FAIL("junk on end"); /* "Can't happen". */
+                                 /* NOTREACHED */
+    }
 
-  return(ret);
+    return (ret);
 }
 
 /*
@@ -347,34 +349,33 @@ int *flagp;
  *
  * Implements the concatenation operator.
  */
-static char *
-regbranch(flagp)
+static char *regbranch(flagp)
 int *flagp;
 {
-  register char *ret;
-  register char *chain;
-  register char *latest;
-  int flags;
+    register char *ret;
+    register char *chain;
+    register char *latest;
+    int flags;
 
-  *flagp = WORST;		/* Tentatively. */
+    *flagp = WORST; /* Tentatively. */
 
-  ret = regnode(BRANCH);
-  chain = NULL;
-  while (*regparse != '\0' && *regparse != '|' && *regparse != ')') {
-	latest = regpiece(&flags);
-	if (latest == NULL)
-		return(NULL);
-	*flagp |= flags&HASWIDTH;
-	if (chain == NULL)	/* First piece. */
-		*flagp |= flags&SPSTART;
-	else
-		regtail(chain, latest);
-	chain = latest;
-  }
-  if (chain == NULL)	/* Loop ran zero times. */
-	(void) regnode(NOTHING);
+    ret = regnode(BRANCH);
+    chain = NULL;
+    while (*regparse != '\0' && *regparse != '|' && *regparse != ')') {
+        latest = regpiece(&flags);
+        if (latest == NULL)
+            return (NULL);
+        *flagp |= flags & HASWIDTH;
+        if (chain == NULL) /* First piece. */
+            *flagp |= flags & SPSTART;
+        else
+            regtail(chain, latest);
+        chain = latest;
+    }
+    if (chain == NULL) /* Loop ran zero times. */
+        (void)regnode(NOTHING);
 
-  return(ret);
+    return (ret);
 }
 
 /*
@@ -386,60 +387,59 @@ int *flagp;
  * It might seem that this node could be dispensed with entirely, but the
  * endmarker role is not redundant.
  */
-static char *
-regpiece(flagp)
+static char *regpiece(flagp)
 int *flagp;
 {
-  register char *ret;
-  register char op;
-  register char *next;
-  int flags;
+    register char *ret;
+    register char op;
+    register char *next;
+    int flags;
 
-  ret = regatom(&flags);
-  if (ret == NULL)
-	return(NULL);
+    ret = regatom(&flags);
+    if (ret == NULL)
+        return (NULL);
 
-  op = *regparse;
-  if (!ISMULT(op)) {
-	*flagp = flags;
-	return(ret);
-  }
+    op = *regparse;
+    if (!ISMULT(op)) {
+        *flagp = flags;
+        return (ret);
+    }
 
-  if (!(flags&HASWIDTH) && op != '?')
-	FAIL("*+ operand could be empty");
-  *flagp = (op != '+') ? (WORST|SPSTART) : (WORST|HASWIDTH);
+    if (!(flags & HASWIDTH) && op != '?')
+        FAIL("*+ operand could be empty");
+    *flagp = (op != '+') ? (WORST | SPSTART) : (WORST | HASWIDTH);
 
-  if (op == '*' && (flags&SIMPLE))
-	reginsert(STAR, ret);
-  else if (op == '*') {
-	/* Emit x* as (x&|), where & means "self". */
-	reginsert(BRANCH, ret);			/* Either x */
-	regoptail(ret, regnode(BACK));		/* and loop */
-	regoptail(ret, ret);			/* back */
-	regtail(ret, regnode(BRANCH));		/* or */
-	regtail(ret, regnode(NOTHING));		/* null. */
-  } else if (op == '+' && (flags&SIMPLE))
-	reginsert(PLUS, ret);
-  else if (op == '+') {
-	/* Emit x+ as x(&|), where & means "self". */
-	next = regnode(BRANCH);			/* Either */
-	regtail(ret, next);
-	regtail(regnode(BACK), ret);		/* loop back */
-	regtail(next, regnode(BRANCH));		/* or */
-	regtail(ret, regnode(NOTHING));		/* null. */
-  } else if (op == '?') {
-	/* Emit x? as (x|) */
-	reginsert(BRANCH, ret);			/* Either x */
-	regtail(ret, regnode(BRANCH));		/* or */
-	next = regnode(NOTHING);		/* null. */
-	regtail(ret, next);
-	regoptail(ret, next);
-  }
-  regparse++;
-  if (ISMULT(*regparse))
-	FAIL("nested *?+");
+    if (op == '*' && (flags & SIMPLE))
+        reginsert(STAR, ret);
+    else if (op == '*') {
+        /* Emit x* as (x&|), where & means "self". */
+        reginsert(BRANCH, ret);         /* Either x */
+        regoptail(ret, regnode(BACK));  /* and loop */
+        regoptail(ret, ret);            /* back */
+        regtail(ret, regnode(BRANCH));  /* or */
+        regtail(ret, regnode(NOTHING)); /* null. */
+    } else if (op == '+' && (flags & SIMPLE))
+        reginsert(PLUS, ret);
+    else if (op == '+') {
+        /* Emit x+ as x(&|), where & means "self". */
+        next = regnode(BRANCH); /* Either */
+        regtail(ret, next);
+        regtail(regnode(BACK), ret);    /* loop back */
+        regtail(next, regnode(BRANCH)); /* or */
+        regtail(ret, regnode(NOTHING)); /* null. */
+    } else if (op == '?') {
+        /* Emit x? as (x|) */
+        reginsert(BRANCH, ret);        /* Either x */
+        regtail(ret, regnode(BRANCH)); /* or */
+        next = regnode(NOTHING);       /* null. */
+        regtail(ret, next);
+        regoptail(ret, next);
+    }
+    regparse++;
+    if (ISMULT(*regparse))
+        FAIL("nested *?+");
 
-  return(ret);
+    return (ret);
 }
 
 /*
@@ -450,148 +450,143 @@ int *flagp;
  * faster to run.  Backslashed characters are exceptions, each becoming a
  * separate node; the code is simpler that way and it's not worth fixing.
  */
-static char *
-regatom(flagp)
+static char *regatom(flagp)
 int *flagp;
 {
-  register char *ret;
-  int flags;
+    register char *ret;
+    int flags;
 
-  *flagp = WORST;		/* Tentatively. */
+    *flagp = WORST; /* Tentatively. */
 
-  switch (*regparse++) {
-  case '^':
-	ret = regnode(BOL);
-	break;
-  case '$':
-	ret = regnode(EOL);
-	break;
-  case '.':
-	ret = regnode(ANY);
-	*flagp |= HASWIDTH|SIMPLE;
-	break;
-  case '[': {
-		register int class;
-		register int classend;
+    switch (*regparse++) {
+    case '^':
+        ret = regnode(BOL);
+        break;
+    case '$':
+        ret = regnode(EOL);
+        break;
+    case '.':
+        ret = regnode(ANY);
+        *flagp |= HASWIDTH | SIMPLE;
+        break;
+    case '[': {
+        register int class;
+        register int classend;
 
-		if (*regparse == '^') {	/* Complement of range. */
-			ret = regnode(ANYBUT);
-			regparse++;
-		} else
-			ret = regnode(ANYOF);
-		if (*regparse == ']' || *regparse == '-')
-			regc(*regparse++);
-		while (*regparse != '\0' && *regparse != ']') {
-			if (*regparse == '-') {
-				regparse++;
-				if (*regparse == ']' || *regparse == '\0')
-					regc('-');
-				else {
-					class = UCHARAT(regparse-2)+1;
-					classend = UCHARAT(regparse);
-					if (class > classend+1)
-						FAIL("invalid [] range");
-					for (; class <= classend; class++)
-						regc(class);
-					regparse++;
-				}
-			} else
-				regc(*regparse++);
-		}
-		regc('\0');
-		if (*regparse != ']')
-			FAIL("unmatched []");
-		regparse++;
-		*flagp |= HASWIDTH|SIMPLE;
-	}
-	break;
-  case '(':
-	ret = reg(1, &flags);
-	if (ret == NULL)
-		return(NULL);
-	*flagp |= flags&(HASWIDTH|SPSTART);
-	break;
-  case '\0':
-  case '|':
-  case ')':
-	FAIL("internal urp");	/* Supposed to be caught earlier. */
-	break;
-  case '?':
-  case '+':
-  case '*':
-	FAIL("?+* follows nothing");
-	break;
-  case '\\':
-	if (*regparse == '\0')
-		FAIL("trailing \\");
-	ret = regnode(EXACTLY);
-	regc(*regparse++);
-	regc('\0');
-	*flagp |= HASWIDTH|SIMPLE;
-	break;
-  default: {
-		register int len;
-		register char ender;
+        if (*regparse == '^') { /* Complement of range. */
+            ret = regnode(ANYBUT);
+            regparse++;
+        } else
+            ret = regnode(ANYOF);
+        if (*regparse == ']' || *regparse == '-')
+            regc(*regparse++);
+        while (*regparse != '\0' && *regparse != ']') {
+            if (*regparse == '-') {
+                regparse++;
+                if (*regparse == ']' || *regparse == '\0')
+                    regc('-');
+                else {
+                    class = UCHARAT(regparse - 2) + 1;
+                    classend = UCHARAT(regparse);
+                    if (class > classend + 1)
+                        FAIL("invalid [] range");
+                    for (; class <= classend; class++)
+                        regc(class);
+                    regparse++;
+                }
+            } else
+                regc(*regparse++);
+        }
+        regc('\0');
+        if (*regparse != ']')
+            FAIL("unmatched []");
+        regparse++;
+        *flagp |= HASWIDTH | SIMPLE;
+    } break;
+    case '(':
+        ret = reg(1, &flags);
+        if (ret == NULL)
+            return (NULL);
+        *flagp |= flags & (HASWIDTH | SPSTART);
+        break;
+    case '\0':
+    case '|':
+    case ')':
+        FAIL("internal urp"); /* Supposed to be caught earlier. */
+        break;
+    case '?':
+    case '+':
+    case '*':
+        FAIL("?+* follows nothing");
+        break;
+    case '\\':
+        if (*regparse == '\0')
+            FAIL("trailing \\");
+        ret = regnode(EXACTLY);
+        regc(*regparse++);
+        regc('\0');
+        *flagp |= HASWIDTH | SIMPLE;
+        break;
+    default: {
+        register int len;
+        register char ender;
 
-		regparse--;
-		len = strcspn(regparse, META);
-		if (len <= 0)
-			FAIL("internal disaster");
-		ender = *(regparse+len);
-		if (len > 1 && ISMULT(ender))
-			len--;		/* Back off clear of ?+* operand. */
-		*flagp |= HASWIDTH;
-		if (len == 1)
-			*flagp |= SIMPLE;
-		ret = regnode(EXACTLY);
-		while (len > 0) {
-			regc(*regparse++);
-			len--;
-		}
-		regc('\0');
-	}
-	break;
-  }
+        regparse--;
+        len = mystrcspn(regparse, META);
+        if (len <= 0)
+            FAIL("internal disaster");
+        ender = *(regparse + len);
+        if (len > 1 && ISMULT(ender))
+            len--; /* Back off clear of ?+* operand. */
+        *flagp |= HASWIDTH;
+        if (len == 1)
+            *flagp |= SIMPLE;
+        ret = regnode(EXACTLY);
+        while (len > 0) {
+            regc(*regparse++);
+            len--;
+        }
+        regc('\0');
+    } break;
+    }
 
-  return(ret);
+    return (ret);
 }
 
 /*
  - regnode - emit a node
  */
-static char *			/* Location. */
+static char * /* Location. */
 regnode(op)
 char op;
 {
-  register char *ret;
-  register char *ptr;
+    register char *ret;
+    register char *ptr;
 
-  ret = regcode;
-  if (ret == &regdummy) {
-	regsize += 3;
-	return(ret);
-  }
+    ret = regcode;
+    if (ret == &regdummy) {
+        regsize += 3;
+        return (ret);
+    }
 
-  ptr = ret;
-  *ptr++ = op;
-  *ptr++ = '\0';		/* Null "next" pointer. */
-  *ptr++ = '\0';
-  regcode = ptr;
+    ptr = ret;
+    *ptr++ = op;
+    *ptr++ = '\0'; /* Null "next" pointer. */
+    *ptr++ = '\0';
+    regcode = ptr;
 
-  return(ret);
+    return (ret);
 }
 
 /*
  - regc - emit (if appropriate) a byte of code
  */
-static void
-regc(b)
-char b;
+static void regc(b) char b;
 {
-  if (regcode != &regdummy)
-	*regcode++ = b;
-  else
-	regsize++;
+    if (regcode != &regdummy)
+        *regcode++ = b;
+    else
+        regsize++;
 }
 
 /*
@@ -599,76 +594,70 @@ char b;
  *
  * Means relocating the operand.
  */
-static void
-reginsert(op, opnd)
-char op;
+static void reginsert(op, opnd) char op;
 char *opnd;
 {
-  register char *src;
-  register char *dst;
-  register char *place;
+    register char *src;
+    register char *dst;
+    register char *place;
 
-  if (regcode == &regdummy) {
-	regsize += 3;
-	return;
-  }
+    if (regcode == &regdummy) {
+        regsize += 3;
+        return;
+    }
 
-  src = regcode;
-  regcode += 3;
-  dst = regcode;
-  while (src > opnd)
-	*--dst = *--src;
+    src = regcode;
+    regcode += 3;
+    dst = regcode;
+    while (src > opnd)
+        *--dst = *--src;
 
-  place = opnd;		/* Op node, where operand used to be. */
-  *place++ = op;
-  *place++ = '\0';
-  *place++ = '\0';
+    place = opnd; /* Op node, where operand used to be. */
+    *place++ = op;
+    *place++ = '\0';
+    *place++ = '\0';
 }
 
 /*
  - regtail - set the next-pointer at the end of a node chain
  */
-static void
-regtail(p, val)
-char *p;
+static void regtail(p, val) char *p;
 char *val;
 {
-  register char *scan;
-  register char *temp;
-  register int offset;
+    register char *scan;
+    register char *temp;
+    register int offset;
 
-  if (p == &regdummy)
-	return;
+    if (p == &regdummy)
+        return;
 
-  /* Find last node. */
-  scan = p;
-  for (;;) {
-	temp = regnext(scan);
-	if (temp == NULL)
-		break;
-	scan = temp;
-  }
+    /* Find last node. */
+    scan = p;
+    for (;;) {
+        temp = regnext(scan);
+        if (temp == NULL)
+            break;
+        scan = temp;
+    }
 
-  if (OP(scan) == BACK)
-	offset = scan - val;
-  else
-	offset = val - scan;
-  *(scan+1) = (offset>>8)&0377;
-  *(scan+2) = offset&0377;
+    if (OP(scan) == BACK)
+        offset = scan - val;
+    else
+        offset = val - scan;
+    *(scan + 1) = (offset >> 8) & 0377;
+    *(scan + 2) = offset & 0377;
 }
 
 /*
  - regoptail - regtail on operand of first argument; nop if operandless
  */
-static void
-regoptail(p, val)
-char *p;
+static void regoptail(p, val) char *p;
 char *val;
 {
-  /* "Operandless" and "op != BRANCH" are synonymous in practice. */
-  if (p == NULL || p == &regdummy || OP(p) != BRANCH)
-	return;
-  regtail(OPERAND(p), val);
+    /* "Operandless" and "op != BRANCH" are synonymous in practice. */
+    if (p == NULL || p == &regdummy || OP(p) != BRANCH)
+        return;
+    regtail(OPERAND(p), val);
 }
 
 /*
@@ -678,10 +667,10 @@ char *val;
 /*
  * Global work variables for regexec().
  */
-static char *reginput;		/* String-input pointer. */
-static char *regbol;		/* Beginning of input, for ^ check. */
-static char **regstartp;	/* Pointer to startp array. */
-static char **regendp;		/* Ditto for endp. */
+static char *reginput;   /* String-input pointer. */
+static char *regbol;     /* Beginning of input, for ^ check. */
+static char **regstartp; /* Pointer to startp array. */
+static char **regendp;   /* Ditto for endp. */
 
 /*
  * Forwards.
@@ -699,97 +688,95 @@ STATIC char *regprop();
 /*
  - regexec - match a regexp against a string
  */
-int
-regexec(prog, string, bolflag)
+int regexec(prog, string, bolflag)
 register regexp *prog;
 register char *string;
 int bolflag;
 {
-  register char *s;
-  extern char *strchr();
+    register char *s;
 
-  /* Be paranoid... */
-  if (prog == NULL || string == NULL) {
-	regerror("NULL parameter");
-	return(0);
-  }
+    /* Be paranoid... */
+    if (prog == NULL || string == NULL) {
+        regerror("NULL parameter");
+        return (0);
+    }
 
-  /* Check validity of program. */
-  if (UCHARAT(prog->program) != MAGIC) {
-	regerror("corrupted program");
-	return(0);
-  }
+    /* Check validity of program. */
+    if (UCHARAT(prog->program) != MAGIC) {
+        regerror("corrupted program");
+        return (0);
+    }
 
-  /* If there is a "must appear" string, look for it. */
-  if (prog->regmust != NULL) {
-	s = string;
-	while ((s = strchr(s, prog->regmust[0])) != NULL) {
-		if (strncmp(s, prog->regmust, prog->regmlen) == 0)
-			break;	/* Found it. */
-		s++;
-	}
-	if (s == NULL)	/* Not present. */
-		return(0);
-  }
+    /* If there is a "must appear" string, look for it. */
+    if (prog->regmust != NULL) {
+        s = string;
+        while ((s = strchr(s, prog->regmust[0])) != NULL) {
+            if (strncmp(s, prog->regmust, prog->regmlen) == 0)
+                break; /* Found it. */
+            s++;
+        }
+        if (s == NULL) /* Not present. */
+            return (0);
+    }
 
-  /* Mark beginning of line for ^ . */
-  if(bolflag)
-	regbol = string;
-  else
-	regbol = NULL;
+    /* Mark beginning of line for ^ . */
+    if (bolflag)
+        regbol = string;
+    else
+        regbol = NULL;
 
-  /* Simplest case:  anchored match need be tried only once. */
-  if (prog->reganch)
-	return(regtry(prog, string));
+    /* Simplest case:  anchored match need be tried only once. */
+    if (prog->reganch)
+        return (regtry(prog, string));
 
-  /* Messy cases:  unanchored match. */
-  s = string;
-  if (prog->regstart != '\0')
-	/* We know what char it must start with. */
-	while ((s = strchr(s, prog->regstart)) != NULL) {
-		if (regtry(prog, s))
-			return(1);
-		s++;
-	}
-  else
-	/* We don't -- general case. */
-	do {
-		if (regtry(prog, s))
-			return(1);
-	} while (*s++ != '\0');
+    /* Messy cases:  unanchored match. */
+    s = string;
+    if (prog->regstart != '\0')
+        /* We know what char it must start with. */
+        while ((s = strchr(s, prog->regstart)) != NULL) {
+            if (regtry(prog, s))
+                return (1);
+            s++;
+        }
+    else
+        /* We don't -- general case. */
+        do {
+            if (regtry(prog, s))
+                return (1);
+        } while (*s++ != '\0');
 
-  /* Failure. */
-  return(0);
+    /* Failure. */
+    return (0);
 }
 
 /*
  - regtry - try match at specific point
  */
-static int			/* 0 failure, 1 success */
+static int /* 0 failure, 1 success */
 regtry(prog, string)
 regexp *prog;
 char *string;
 {
-  register int i;
-  register char **sp;
-  register char **ep;
+    register int i;
+    register char **sp;
+    register char **ep;
 
-  reginput = string;
-  regstartp = prog->startp;
-  regendp = prog->endp;
+    reginput = string;
+    regstartp = prog->startp;
+    regendp = prog->endp;
 
-  sp = prog->startp;
-  ep = prog->endp;
-  for (i = NSUBEXP; i > 0; i--) {
-	*sp++ = NULL;
-	*ep++ = NULL;
-  }
-  if (regmatch(prog->program + 1)) {
-	prog->startp[0] = string;
-	prog->endp[0] = reginput;
-	return(1);
-  } else
-	return(0);
+    sp = prog->startp;
+    ep = prog->endp;
+    for (i = NSUBEXP; i > 0; i--) {
+        *sp++ = NULL;
+        *ep++ = NULL;
+    }
+    if (regmatch(prog->program + 1)) {
+        prog->startp[0] = string;
+        prog->endp[0] = reginput;
+        return (1);
+    } else
+        return (0);
 }
 
 /*
@@ -802,257 +789,249 @@ char *string;
  * need to know whether the rest of the match failed) by a loop instead of
  * by recursion.
  */
-static int			/* 0 failure, 1 success */
+static int /* 0 failure, 1 success */
 regmatch(prog)
 char *prog;
 {
-  register char *scan;	/* Current node. */
-  char *next;		/* Next node. */
-  extern char *strchr();
+    register char *scan; /* Current node. */
+    char *next;          /* Next node. */
 
-  scan = prog;
+    scan = prog;
 #ifdef DEBUG
-  if (scan != NULL && regnarrate)
-	fprintf(stderr, "%s(\n", regprop(scan));
+    if (scan != NULL && regnarrate)
+        fprintf(stderr, "%s(\n", regprop(scan));
 #endif
-  while (scan != NULL) {
+    while (scan != NULL) {
 #ifdef DEBUG
-	if (regnarrate)
-		fprintf(stderr, "%s...\n", regprop(scan));
+        if (regnarrate)
+            fprintf(stderr, "%s...\n", regprop(scan));
 #endif
-	next = regnext(scan);
+        next = regnext(scan);
 
-	switch (OP(scan)) {
-	case BOL:
-		if (reginput != regbol)
-			return(0);
-		break;
-	case EOL:
-		if (*reginput != '\0')
-			return(0);
-		break;
-	case ANY:
-		if (*reginput == '\0')
-			return(0);
-		reginput++;
-		break;
-	case EXACTLY: {
-			register int len;
-			register char *opnd;
+        switch (OP(scan)) {
+        case BOL:
+            if (reginput != regbol)
+                return (0);
+            break;
+        case EOL:
+            if (*reginput != '\0')
+                return (0);
+            break;
+        case ANY:
+            if (*reginput == '\0')
+                return (0);
+            reginput++;
+            break;
+        case EXACTLY: {
+            register int len;
+            register char *opnd;
 
-			opnd = OPERAND(scan);
-			/* Inline the first character, for speed. */
-			if (*opnd != *reginput)
-				return(0);
-			len = strlen(opnd);
-			if (len > 1 && strncmp(opnd, reginput, len) != 0)
-				return(0);
-			reginput += len;
-		}
-		break;
-	case ANYOF:
-		if (*reginput == '\0' || strchr(OPERAND(scan), *reginput) == NULL)
-			return(0);
-		reginput++;
-		break;
-	case ANYBUT:
-		if (*reginput == '\0' || strchr(OPERAND(scan), *reginput) != NULL)
-			return(0);
-		reginput++;
-		break;
-	case NOTHING:
-		break;
-	case BACK:
-		break;
-	case OPEN+1:
-	case OPEN+2:
-	case OPEN+3:
-	case OPEN+4:
-	case OPEN+5:
-	case OPEN+6:
-	case OPEN+7:
-	case OPEN+8:
-	case OPEN+9: {
-			register int no;
-			register char *save;
+            opnd = OPERAND(scan);
+            /* Inline the first character, for speed. */
+            if (*opnd != *reginput)
+                return (0);
+            len = strlen(opnd);
+            if (len > 1 && strncmp(opnd, reginput, len) != 0)
+                return (0);
+            reginput += len;
+        } break;
+        case ANYOF:
+            if (*reginput == '\0' || strchr(OPERAND(scan), *reginput) == NULL)
+                return (0);
+            reginput++;
+            break;
+        case ANYBUT:
+            if (*reginput == '\0' || strchr(OPERAND(scan), *reginput) != NULL)
+                return (0);
+            reginput++;
+            break;
+        case NOTHING:
+            break;
+        case BACK:
+            break;
+        case OPEN + 1:
+        case OPEN + 2:
+        case OPEN + 3:
+        case OPEN + 4:
+        case OPEN + 5:
+        case OPEN + 6:
+        case OPEN + 7:
+        case OPEN + 8:
+        case OPEN + 9: {
+            register int no;
+            register char *save;
 
-			no = OP(scan) - OPEN;
-			save = reginput;
+            no = OP(scan) - OPEN;
+            save = reginput;
 
-			if (regmatch(next)) {
-				/*
-				 * Don't set startp if some later
-				 * invocation of the same parentheses
-				 * already has.
-				 */
-				if (regstartp[no] == NULL)
-					regstartp[no] = save;
-				return(1);
-			} else
-				return(0);
-		}
-		break;
-	case CLOSE+1:
-	case CLOSE+2:
-	case CLOSE+3:
-	case CLOSE+4:
-	case CLOSE+5:
-	case CLOSE+6:
-	case CLOSE+7:
-	case CLOSE+8:
-	case CLOSE+9: {
-			register int no;
-			register char *save;
+            if (regmatch(next)) {
+                /*
+                 * Don't set startp if some later
+                 * invocation of the same parentheses
+                 * already has.
+                 */
+                if (regstartp[no] == NULL)
+                    regstartp[no] = save;
+                return (1);
+            } else
+                return (0);
+        } break;
+        case CLOSE + 1:
+        case CLOSE + 2:
+        case CLOSE + 3:
+        case CLOSE + 4:
+        case CLOSE + 5:
+        case CLOSE + 6:
+        case CLOSE + 7:
+        case CLOSE + 8:
+        case CLOSE + 9: {
+            register int no;
+            register char *save;
 
-			no = OP(scan) - CLOSE;
-			save = reginput;
+            no = OP(scan) - CLOSE;
+            save = reginput;
 
-			if (regmatch(next)) {
-				/*
-				 * Don't set endp if some later
-				 * invocation of the same parentheses
-				 * already has.
-				 */
-				if (regendp[no] == NULL)
-					regendp[no] = save;
-				return(1);
-			} else
-				return(0);
-		}
-		break;
-	case BRANCH: {
-			register char *save;
+            if (regmatch(next)) {
+                /*
+                 * Don't set endp if some later
+                 * invocation of the same parentheses
+                 * already has.
+                 */
+                if (regendp[no] == NULL)
+                    regendp[no] = save;
+                return (1);
+            } else
+                return (0);
+        } break;
+        case BRANCH: {
+            register char *save;
 
-			if (OP(next) != BRANCH)		/* No choice. */
-				next = OPERAND(scan);	/* Avoid recursion. */
-			else {
-				do {
-					save = reginput;
-					if (regmatch(OPERAND(scan)))
-						return(1);
-					reginput = save;
-					scan = regnext(scan);
-				} while (scan != NULL && OP(scan) == BRANCH);
-				return(0);
-				/* NOTREACHED */
-			}
-		}
-		break;
-	case STAR:
-	case PLUS: {
-			register char nextch;
-			register int no;
-			register char *save;
-			register int min;
+            if (OP(next) != BRANCH)   /* No choice. */
+                next = OPERAND(scan); /* Avoid recursion. */
+            else {
+                do {
+                    save = reginput;
+                    if (regmatch(OPERAND(scan)))
+                        return (1);
+                    reginput = save;
+                    scan = regnext(scan);
+                } while (scan != NULL && OP(scan) == BRANCH);
+                return (0);
+                /* NOTREACHED */
+            }
+        } break;
+        case STAR:
+        case PLUS: {
+            register char nextch;
+            register int no;
+            register char *save;
+            register int min;
 
-			/*
-			 * Lookahead to avoid useless match attempts
-			 * when we know what character comes next.
-			 */
-			nextch = '\0';
-			if (OP(next) == EXACTLY)
-				nextch = *OPERAND(next);
-			min = (OP(scan) == STAR) ? 0 : 1;
-			save = reginput;
-			no = regrepeat(OPERAND(scan));
-			while (no >= min) {
-				/* If it could work, try it. */
-				if (nextch == '\0' || *reginput == nextch)
-					if (regmatch(next))
-						return(1);
-				/* Couldn't or didn't -- back up. */
-				no--;
-				reginput = save + no;
-			}
-			return(0);
-		}
-		break;
-	case END:
-		return(1);	/* Success! */
-		break;
-	default:
-		regerror("memory corruption");
-		return(0);
-		break;
-	}
+            /*
+             * Lookahead to avoid useless match attempts
+             * when we know what character comes next.
+             */
+            nextch = '\0';
+            if (OP(next) == EXACTLY)
+                nextch = *OPERAND(next);
+            min = (OP(scan) == STAR) ? 0 : 1;
+            save = reginput;
+            no = regrepeat(OPERAND(scan));
+            while (no >= min) {
+                /* If it could work, try it. */
+                if (nextch == '\0' || *reginput == nextch)
+                    if (regmatch(next))
+                        return (1);
+                /* Couldn't or didn't -- back up. */
+                no--;
+                reginput = save + no;
+            }
+            return (0);
+        } break;
+        case END:
+            return (1); /* Success! */
+            break;
+        default:
+            regerror("memory corruption");
+            return (0);
+            break;
+        }
 
-	scan = next;
-  }
+        scan = next;
+    }
 
-  /*
-   * We get here only if there's trouble -- normally "case END" is
-   * the terminating point.
-   */
-  regerror("corrupted pointers");
-  return(0);
+    /*
+     * We get here only if there's trouble -- normally "case END" is
+     * the terminating point.
+     */
+    regerror("corrupted pointers");
+    return (0);
 }
 
 /*
  - regrepeat - repeatedly match something simple, report how many
  */
-static int
-regrepeat(p)
+static int regrepeat(p)
 char *p;
 {
-  register int count = 0;
-  register char *scan;
-  register char *opnd;
+    register int count = 0;
+    register char *scan;
+    register char *opnd;
 
-  scan = reginput;
-  opnd = OPERAND(p);
-  switch (OP(p)) {
-  case ANY:
-	count = strlen(scan);
-	scan += count;
-	break;
-  case EXACTLY:
-	while (*opnd == *scan) {
-		count++;
-		scan++;
-	}
-	break;
-  case ANYOF:
-	while (*scan != '\0' && strchr(opnd, *scan) != NULL) {
-		count++;
-		scan++;
-	}
-	break;
-  case ANYBUT:
-	while (*scan != '\0' && strchr(opnd, *scan) == NULL) {
-		count++;
-		scan++;
-	}
-	break;
-  default:		/* Oh dear.  Called inappropriately. */
-	regerror("internal foulup");
-	count = 0;	/* Best compromise. */
-	break;
-  }
-  reginput = scan;
+    scan = reginput;
+    opnd = OPERAND(p);
+    switch (OP(p)) {
+    case ANY:
+        count = strlen(scan);
+        scan += count;
+        break;
+    case EXACTLY:
+        while (*opnd == *scan) {
+            count++;
+            scan++;
+        }
+        break;
+    case ANYOF:
+        while (*scan != '\0' && strchr(opnd, *scan) != NULL) {
+            count++;
+            scan++;
+        }
+        break;
+    case ANYBUT:
+        while (*scan != '\0' && strchr(opnd, *scan) == NULL) {
+            count++;
+            scan++;
+        }
+        break;
+    default: /* Oh dear.  Called inappropriately. */
+        regerror("internal foulup");
+        count = 0; /* Best compromise. */
+        break;
+    }
+    reginput = scan;
 
-  return(count);
+    return (count);
 }
 
 /*
  - regnext - dig the "next" pointer out of a node
  */
-static char *
-regnext(p)
+static char *regnext(p)
 register char *p;
 {
-  register int offset;
+    register int offset;
 
-  if (p == &regdummy)
-	return(NULL);
+    if (p == &regdummy)
+        return (NULL);
 
-  offset = NEXT(p);
-  if (offset == 0)
-	return(NULL);
+    offset = NEXT(p);
+    if (offset == 0)
+        return (NULL);
 
-  if (OP(p) == BACK)
-	return(p-offset);
-  else
-	return(p+offset);
+    if (OP(p) == BACK)
+        return (p - offset);
+    else
+        return (p + offset);
 }
 
 #ifdef DEBUG
@@ -1062,127 +1041,122 @@ STATIC char *regprop();
 /*
  - regdump - dump a regexp onto stdout in vaguely comprehensible form
  */
-void
-regdump(r)
-regexp *r;
+void regdump(r) regexp *r;
 {
-  register char *s;
-  register char op = EXACTLY;	/* Arbitrary non-END op. */
-  register char *next;
-  extern char *strchr();
+    register char *s;
+    register char op = EXACTLY; /* Arbitrary non-END op. */
+    register char *next;
 
+    s = r->program + 1;
+    while (op != END) { /* While that wasn't END last time... */
+        op = OP(s);
+        printf("%2d%s", s - r->program, regprop(s)); /* Where, what. */
+        next = regnext(s);
+        if (next == NULL) /* Next ptr. */
+            printf("(0)");
+        else
+            printf("(%d)", (s - r->program) + (next - s));
+        s += 3;
+        if (op == ANYOF || op == ANYBUT || op == EXACTLY) {
+            /* Literal string, where present. */
+            while (*s != '\0') {
+                putchar(*s);
+                s++;
+            }
+            s++;
+        }
+        putchar('\n');
+    }
 
-  s = r->program + 1;
-  while (op != END) {	/* While that wasn't END last time... */
-	op = OP(s);
-	printf("%2d%s", s-r->program, regprop(s));	/* Where, what. */
-	next = regnext(s);
-	if (next == NULL)		/* Next ptr. */
-		printf("(0)");
-	else 
-		printf("(%d)", (s-r->program)+(next-s));
-	s += 3;
-	if (op == ANYOF || op == ANYBUT || op == EXACTLY) {
-		/* Literal string, where present. */
-		while (*s != '\0') {
-			putchar(*s);
-			s++;
-		}
-		s++;
-	}
-	putchar('\n');
-  }
-
-  /* Header fields of interest. */
-  if (r->regstart != '\0')
-	printf("start `%c' ", r->regstart);
-  if (r->reganch)
-	printf("anchored ");
-  if (r->regmust != NULL)
-	printf("must have \"%s\"", r->regmust);
-  printf("\n");
+    /* Header fields of interest. */
+    if (r->regstart != '\0')
+        printf("start `%c' ", r->regstart);
+    if (r->reganch)
+        printf("anchored ");
+    if (r->regmust != NULL)
+        printf("must have \"%s\"", r->regmust);
+    printf("\n");
 }
 
 /*
  - regprop - printable representation of opcode
  */
-static char *
-regprop(op)
+static char *regprop(op)
 char *op;
 {
-  register char *p;
-  static char buf[50];
+    register char *p;
+    static char buf[50];
 
-  (void) strcpy(buf, ":");
+    (void)strcpy(buf, ":");
 
-  switch (OP(op)) {
-  case BOL:
-	p = "BOL";
-	break;
-  case EOL:
-	p = "EOL";
-	break;
-  case ANY:
-	p = "ANY";
-	break;
-  case ANYOF:
-	p = "ANYOF";
-	break;
-  case ANYBUT:
-	p = "ANYBUT";
-	break;
-  case BRANCH:
-	p = "BRANCH";
-	break;
-  case EXACTLY:
-	p = "EXACTLY";
-	break;
-  case NOTHING:
-	p = "NOTHING";
-	break;
-  case BACK:
-	p = "BACK";
-	break;
-  case END:
-	p = "END";
-	break;
-  case OPEN+1:
-  case OPEN+2:
-  case OPEN+3:
-  case OPEN+4:
-  case OPEN+5:
-  case OPEN+6:
-  case OPEN+7:
-  case OPEN+8:
-  case OPEN+9:
-	sprintf(buf+strlen(buf), "OPEN%d", OP(op)-OPEN);
-	p = NULL;
-	break;
-  case CLOSE+1:
-  case CLOSE+2:
-  case CLOSE+3:
-  case CLOSE+4:
-  case CLOSE+5:
-  case CLOSE+6:
-  case CLOSE+7:
-  case CLOSE+8:
-  case CLOSE+9:
-	sprintf(buf+strlen(buf), "CLOSE%d", OP(op)-CLOSE);
-	p = NULL;
-	break;
-  case STAR:
-	p = "STAR";
-	break;
-  case PLUS:
-	p = "PLUS";
-	break;
-  default:
-	regerror("corrupted opcode");
-	break;
-  }
-  if (p != NULL)
-	(void) strcat(buf, p);
-  return(buf);
+    switch (OP(op)) {
+    case BOL:
+        p = "BOL";
+        break;
+    case EOL:
+        p = "EOL";
+        break;
+    case ANY:
+        p = "ANY";
+        break;
+    case ANYOF:
+        p = "ANYOF";
+        break;
+    case ANYBUT:
+        p = "ANYBUT";
+        break;
+    case BRANCH:
+        p = "BRANCH";
+        break;
+    case EXACTLY:
+        p = "EXACTLY";
+        break;
+    case NOTHING:
+        p = "NOTHING";
+        break;
+    case BACK:
+        p = "BACK";
+        break;
+    case END:
+        p = "END";
+        break;
+    case OPEN + 1:
+    case OPEN + 2:
+    case OPEN + 3:
+    case OPEN + 4:
+    case OPEN + 5:
+    case OPEN + 6:
+    case OPEN + 7:
+    case OPEN + 8:
+    case OPEN + 9:
+        sprintf(buf + strlen(buf), "OPEN%d", OP(op) - OPEN);
+        p = NULL;
+        break;
+    case CLOSE + 1:
+    case CLOSE + 2:
+    case CLOSE + 3:
+    case CLOSE + 4:
+    case CLOSE + 5:
+    case CLOSE + 6:
+    case CLOSE + 7:
+    case CLOSE + 8:
+    case CLOSE + 9:
+        sprintf(buf + strlen(buf), "CLOSE%d", OP(op) - CLOSE);
+        p = NULL;
+        break;
+    case STAR:
+        p = "STAR";
+        break;
+    case PLUS:
+        p = "PLUS";
+        break;
+    default:
+        regerror("corrupted opcode");
+        break;
+    }
+    if (p != NULL)
+        (void)strcat(buf, p);
+    return (buf);
 }
 #endif
 
@@ -1197,21 +1171,20 @@ char *op;
  * of characters not from s2
  */
 
-static int
-strcspn(s1, s2)
+static int mystrcspn(s1, s2)
 char *s1;
 char *s2;
 {
-  register char *scan1;
-  register char *scan2;
-  register int count;
+    register char *scan1;
+    register char *scan2;
+    register int count;
 
-  count = 0;
-  for (scan1 = s1; *scan1 != '\0'; scan1++) {
-	for (scan2 = s2; *scan2 != '\0';)	/* ++ moved down. */
-		if (*scan1 == *scan2++)
-			return(count);
-	count++;
-  }
-  return(count);
+    count = 0;
+    for (scan1 = s1; *scan1 != '\0'; scan1++) {
+        for (scan2 = s2; *scan2 != '\0';) /* ++ moved down. */
+            if (*scan1 == *scan2++)
+                return (count);
+        count++;
+    }
+    return (count);
 }

--- a/lib/scanf.c
+++ b/lib/scanf.c
@@ -1,315 +1,35 @@
-/* scanf - formatted input conversion	Author: Patrick van Kleef */
-
+#include <stdarg.h>
 #include <stdio.h>
 
-
-int scanf (format, args)
-char           *format;
-unsigned        args;
-{
-	return _doscanf (0, stdin, format, &args);
-}
-
-
-
-int fscanf (fp, format, args)
-FILE           *fp;
-char           *format;
-unsigned        args;
-{
-	return _doscanf (0, fp, format, &args);
-}
-
-
-int sscanf (string, format, args)
-char           *string;		/* source of data */
-char           *format;		/* control string */
-unsigned        args;		/* our args */
-{
-	return _doscanf (1, string, format, &args);
-}
-
-
-union ptr_union {
-	char           *chr_p;
-	unsigned int   *uint_p;
-	unsigned long  *ulong_p;
-};
-
-static int      ic;		/* the current character */
-static char    *rnc_arg;	/* the string or the filepointer */
-static          rnc_code;	/* 1 = read from string, else from FILE */
-
-
-
-
-/* get the next character */
-
-static rnc ()
-{
-	if (rnc_code) {
-		if (!(ic = *rnc_arg++))
-			ic = EOF;
-	} else
-		ic = getc ((FILE *) rnc_arg);
-}
-
-
-
 /*
- * unget the current character 
+ * Simplified scanf wrappers that delegate to the host C library.
+ * These maintain the traditional interface while relying on the
+ * platform implementation of the corresponding v* functions.
  */
 
-static ugc ()
-{
-
-	if (rnc_code)
-		--rnc_arg;
-	else
-		ungetc (ic, rnc_arg);
+int scanf(const char *format, ...) {
+    va_list ap;
+    int ret;
+    va_start(ap, format);
+    ret = vscanf(format, ap);
+    va_end(ap);
+    return ret;
 }
 
-
-
-static index(ch, string)
-char ch;
-char *string;
-{
-	while (*string++ != ch) 
-		if (!*string)
-			return 0;
-	return 1;
+int fscanf(FILE *fp, const char *format, ...) {
+    va_list ap;
+    int ret;
+    va_start(ap, format);
+    ret = vfscanf(fp, format, ap);
+    va_end(ap);
+    return ret;
 }
 
-
-/*
- * this is cheaper than iswhite from <ctype.h> 
- */
-
-static iswhite (ch)
-int             ch;
-{
-
-	return (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r');
-}
-
-
-
-
-
-static isdigit (ch)
-int             ch;
-{
-	return (ch >= '0' && ch <= '9');
-}
-
-
-
-
-static tolower (ch)
-int             ch;
-{
-	if (ch >= 'A' && ch <= 'Z')
-		ch = ch + 'a' - 'A';
-
-	return ch;
-}
-
-
-/*
- * the routine that does the job 
- */
-
-_doscanf (code, funcarg, format, argp)
-int             code;		/* function to get a character */
-char           *funcarg;	/* an argument for the function */
-char           *format;		/* the format control string */
-union ptr_union *argp;		/* our argument list */
-{
-	int             done = 0;	/* number of items done */
-	int             base;		/* conversion base */
-	long            val;		/* an integer value */
-	int             sign;		/* sign flag */
-	int             do_assign;	/* assignment suppression flag */
-	unsigned        width;		/* width of field */
-	int             widflag;	/* width was specified */
-	int             longflag;	/* true if long */
-	int             done_some;	/* true if we have seen some data */
-	int		reverse;	/* reverse the checking in [...] */
-	char	       *endbracket;     /* position of the ] in format string */
-
-	rnc_arg = funcarg;
-	rnc_code = code;
-
-	rnc ();			/* read the next character */
-
-	if (ic == EOF) {
-		done = EOF;
-		goto quit;
-	}
-
-	while (1) {
-		while (iswhite (*format))
-			++format;	/* skip whitespace */
-		if (!*format)
-			goto all_done;	/* end of format */
-		if (ic < 0)
-			goto quit;	/* seen an error */
-		if (*format != '%') {
-			while (iswhite (ic))
-				rnc ();
-			if (ic != *format)
-				goto all_done;
-			++format;
-			rnc ();
-			++done;
-			continue;
-		}
-		++format;
-		do_assign = 1;
-		if (*format == '*') {
-			++format;
-			do_assign = 0;
-		}
-		if (isdigit (*format)) {
-			widflag = 1;
-			for (width = 0; isdigit (*format);)
-				width = width * 10 + *format++ - '0';
-		} else
-			widflag = 0;	/* no width spec */
-		if (longflag = (tolower (*format) == 'l'))
-			++format;
-		if (*format != 'c')
-			while (iswhite (ic))
-				rnc ();
-		done_some = 0;	/* nothing yet */
-		switch (*format) {
-		case 'o':
-			base = 8;
-			goto decimal;
-		case 'u':
-		case 'd':
-			base = 10;
-			goto decimal;
-		case 'x':
-			base = 16;
-			if (((!widflag) || width >= 2) && ic == '0') {
-				rnc ();
-				if (tolower (ic) == 'x') {
-					width -= 2;
-					done_some = 1;
-					rnc ();
-				} else {
-					ugc ();
-					ic = '0';
-				}
-			}
-	decimal:
-			val = 0L;	/* our result value */
-			sign = 0;	/* assume positive */
-			if (!widflag)
-				width = 0xffff;	/* very wide */
-			if (width && ic == '+')
-				rnc ();
-			else if (width && ic == '-') {
-				sign = 1;
-				rnc ();
-			}
-			while (width--) {
-				if (isdigit (ic) && ic - '0' < base)
-					ic -= '0';
-				else if (base == 16 && tolower (ic) >= 'a' && tolower (ic) <= 'f')
-					ic = 10 + tolower (ic) - 'a';
-				else
-					break;
-				val = val * base + ic;
-				rnc ();
-				done_some = 1;
-			}
-			if (do_assign) {
-				if (sign)
-					val = -val;
-				if (longflag)
-					*(argp++)->ulong_p = (unsigned long) val;
-				else
-					*(argp++)->uint_p = (unsigned) val;
-			}
-			if (done_some)
-				++done;
-			else
-				goto all_done;
-			break;
-		case 'c':
-			if (!widflag)
-				width = 1;
-			while (width-- && ic >= 0) {
-				if (do_assign)
-					*(argp)->chr_p++ = (char) ic;
-				rnc ();
-				done_some = 1;
-			}
-			if (do_assign)
-				argp++;	/* done with this one */
-			if (done_some)
-				++done;
-			break;
-		case 's':
-			if (!widflag)
-				width = 0xffff;
-			while (width-- && !iswhite (ic) && ic > 0) {
-				if (do_assign)
-					*(argp)->chr_p++ = (char) ic;
-				rnc ();
-				done_some = 1;
-			}
-			if (do_assign)		/* terminate the string */
-				*(argp++)->chr_p = '\0';	
-			if (done_some)
-				++done;
-			else
-				goto all_done;
-			break;
-		case '[':
-			if (!widflag)
-				width = 0xffff;
-
-			if ( *(++format) == '^' ) {
-				reverse = 1;
-				format++;
-			} else
-				reverse = 0;
-			
-			endbracket = format;
-			while ( *endbracket != ']'  && *endbracket != '\0')
-				endbracket++;
-			
-			if (!*endbracket)
-				goto quit;
-			
-			*endbracket = '\0';	/* change format string */
-
-			while (width-- && !iswhite (ic) && ic > 0 &&
-				(index (ic, format) ^ reverse)) {
-				if (do_assign)
-					*(argp)->chr_p++ = (char) ic;
-				rnc ();
-				done_some = 1;
-			}
-			format = endbracket;
-			*format = ']';		/* put it back */
-			if (do_assign)		/* terminate the string */
-				*(argp++)->chr_p = '\0';	
-			if (done_some)
-				++done;
-			else
-				goto all_done;
-			break;
-		}		/* end switch */
-		++format;
-	}
-all_done:
-	if (ic >= 0)
-		ugc ();		/* restore the character */
-quit:
-	return done;
+int sscanf(const char *str, const char *format, ...) {
+    va_list ap;
+    int ret;
+    va_start(ap, format);
+    ret = vsscanf(str, format, ap);
+    va_end(ap);
+    return ret;
 }

--- a/lib/setjmp.c
+++ b/lib/setjmp.c
@@ -1,14 +1,12 @@
-#include <setjmp.h>
-#include <stdlib.h>
-#include "../include/lib.h"
 #include "../include/setjmp.h"
+#include "../include/lib.h"
+#include <stdlib.h>
 
 /*
  * Portable implementation of _setjmp using the host C library.
  * The custom jmp_buf stores a pointer to the real jmp_buf.
  */
-PUBLIC int _setjmp(jmp_buf env)
-{
+PUBLIC int _setjmp(jmp_buf env) {
     jmp_buf *real = safe_malloc(sizeof(jmp_buf));
     *(jmp_buf **)env = real;
     return setjmp(*real);
@@ -17,8 +15,7 @@ PUBLIC int _setjmp(jmp_buf env)
 /*
  * Portable implementation of _longjmp using the host C library.
  */
-PUBLIC void _longjmp(jmp_buf env, int val)
-{
+PUBLIC void _longjmp(jmp_buf env, int val) {
     jmp_buf *real = *(jmp_buf **)env;
     if (val == 0) {
         val = 1;

--- a/lib/syscall_x86_64.c
+++ b/lib/syscall_x86_64.c
@@ -1,35 +1,41 @@
 #ifdef __x86_64__
 #include "../h/com.h"
+#include "../h/const.h"
 #include "../h/type.h"
 
-PUBLIC int send(int dst, message *m_ptr)
-{
-    register long rax asm("rax") = 0;
-    register long rdi asm("rdi") = dst;
-    register message *rsi asm("rsi") = m_ptr;
-    register long rdx asm("rdx") = SEND;
-    asm volatile ("syscall" : "=a"(rax) : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax) : "rcx", "r11", "memory");
+PUBLIC int send(int dst, message *m_ptr) {
+    register long rax __asm__("rax") = 0;
+    register long rdi __asm__("rdi") = dst;
+    register message *rsi __asm__("rsi") = m_ptr;
+    register long rdx __asm__("rdx") = SEND;
+    __asm__ volatile("syscall"
+                     : "=a"(rax)
+                     : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax)
+                     : "rcx", "r11", "memory");
     return (int)rax;
 }
 
-PUBLIC int receive(int src, message *m_ptr)
-{
-    register long rax asm("rax") = 0;
-    register long rdi asm("rdi") = src;
-    register message *rsi asm("rsi") = m_ptr;
-    register long rdx asm("rdx") = RECEIVE;
-    asm volatile ("syscall" : "=a"(rax) : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax) : "rcx", "r11", "memory");
+PUBLIC int receive(int src, message *m_ptr) {
+    register long rax __asm__("rax") = 0;
+    register long rdi __asm__("rdi") = src;
+    register message *rsi __asm__("rsi") = m_ptr;
+    register long rdx __asm__("rdx") = RECEIVE;
+    __asm__ volatile("syscall"
+                     : "=a"(rax)
+                     : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax)
+                     : "rcx", "r11", "memory");
     return (int)rax;
 }
 
-PUBLIC int sendrec(int srcdest, message *m_ptr)
-{
-    register long rax asm("rax") = 0;
-    register long rdi asm("rdi") = srcdest;
-    register message *rsi asm("rsi") = m_ptr;
-    register long rdx asm("rdx") = BOTH;
-    asm volatile ("syscall" : "=a"(rax) : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax) : "rcx", "r11", "memory");
+PUBLIC int sendrec(int srcdest, message *m_ptr) {
+    register long rax __asm__("rax") = 0;
+    register long rdi __asm__("rdi") = srcdest;
+    register message *rsi __asm__("rsi") = m_ptr;
+    register long rdx __asm__("rdx") = BOTH;
+    __asm__ volatile("syscall"
+                     : "=a"(rax)
+                     : "D"(rdi), "S"(rsi), "d"(rdx), "a"(rax)
+                     : "rcx", "r11", "memory");
     return (int)rax;
 }
 #endif
-

--- a/lib/syslib.c
+++ b/lib/syslib.c
@@ -1,129 +1,121 @@
-#include "../h/const.h"
-#include "../h/type.h"
 #include "../h/callnr.h"
 #include "../h/com.h"
+#include "../h/const.h"
 #include "../h/error.h"
+#include "../h/type.h"
+#include <signal.h>
 
-#define FS          FS_PROC_NR
-#define MM          MMPROCNR
+#ifndef sighandler_t
+typedef void (*sighandler_t)(int);
+#endif
+
+#define FS FS_PROC_NR
+#define MM MMPROCNR
 
 extern int errno;
 extern message M;
 
-
 /*----------------------------------------------------------------------------
-			Messages to systask (special calls)
+            Messages to systask (special calls)
 ----------------------------------------------------------------------------*/
 
 PUBLIC sys_xit(parent, proc)
-int parent;			/* parent of exiting proc. */
-int proc;			/* which proc has exited */
+int parent; /* parent of exiting proc. */
+int proc;   /* which proc has exited */
 {
-/* A proc has exited.  Tell the kernel. */
+    /* A proc has exited.  Tell the kernel. */
 
-  callm1(SYSTASK, SYS_XIT, parent, proc, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    callm1(SYSTASK, SYS_XIT, parent, proc, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }
-
 
 PUBLIC sys_getsp(proc, newsp)
-int proc;			/* which proc has enabled signals */
-vir_bytes *newsp;		/* place to put sp read from kernel */
+int proc;         /* which proc has enabled signals */
+vir_bytes *newsp; /* place to put sp read from kernel */
 {
-/* Ask the kernel what the sp is. */
+    /* Ask the kernel what the sp is. */
 
-
-  callm1(SYSTASK, SYS_GETSP, proc, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-  *newsp = (vir_bytes) M.STACK_PTR;
+    callm1(SYSTASK, SYS_GETSP, proc, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    *newsp = (vir_bytes)M.STACK_PTR;
 }
 
+PUBLIC sys_sig(int proc, int sig, sighandler_t sighandler) {
+    /* A proc has to be signaled.  Tell the kernel. */
 
-PUBLIC sys_sig(int proc, int sig, sighandler_t sighandler)
-{
-/* A proc has to be signaled.  Tell the kernel. */
-
-  M.m6_i1 = proc;
-  M.m6_i2 = sig;
-  M.m6_f1 = sighandler;
-  callx(SYSTASK, SYS_SIG);
+    M.m6_i1 = proc;
+    M.m6_i2 = sig;
+    M.m6_f1 = sighandler;
+    callx(SYSTASK, SYS_SIG);
 }
-
 
 PUBLIC sys_fork(parent, child, pid)
-int parent;			/* proc doing the fork */
-int child;			/* which proc has been created by the fork */
-int pid;			/* process id assigned by MM */
+int parent; /* proc doing the fork */
+int child;  /* which proc has been created by the fork */
+int pid;    /* process id assigned by MM */
 {
-/* A proc has forked.  Tell the kernel. */
+    /* A proc has forked.  Tell the kernel. */
 
-  callm1(SYSTASK, SYS_FORK, parent, child, pid, NIL_PTR, NIL_PTR, NIL_PTR);
+    callm1(SYSTASK, SYS_FORK, parent, child, pid, NIL_PTR, NIL_PTR, NIL_PTR);
 }
 
-
 PUBLIC sys_exec(proc, ptr)
-int proc;			/* proc that did exec */
-char *ptr;			/* new stack pointer */
+int proc;  /* proc that did exec */
+char *ptr; /* new stack pointer */
 {
-/* A proc has exec'd.  Tell the kernel. */
+    /* A proc has exec'd.  Tell the kernel. */
 
-  callm1(SYSTASK, SYS_EXEC, proc, 0, 0, ptr, NIL_PTR, NIL_PTR);
+    callm1(SYSTASK, SYS_EXEC, proc, 0, 0, ptr, NIL_PTR, NIL_PTR);
 }
 
 PUBLIC sys_newmap(proc, ptr)
-int proc;			/* proc whose map is to be changed */
-char *ptr;			/* pointer to new map */
+int proc;  /* proc whose map is to be changed */
+char *ptr; /* pointer to new map */
 {
-/* A proc has been assigned a new memory map.  Tell the kernel. */
+    /* A proc has been assigned a new memory map.  Tell the kernel. */
 
-
-  callm1(SYSTASK, SYS_NEWMAP, proc, 0, 0, ptr, NIL_PTR, NIL_PTR);
+    callm1(SYSTASK, SYS_NEWMAP, proc, 0, 0, ptr, NIL_PTR, NIL_PTR);
 }
 
 PUBLIC sys_copy(mptr)
-message *mptr;			/* pointer to message */
+message *mptr; /* pointer to message */
 {
-/* A proc wants to use local copy. */
+    /* A proc wants to use local copy. */
 
-  /* Make this routine better.  Also check other guys' error handling -DEBUG */
-  mptr->m_type = SYS_COPY;
-  if (sendrec(SYSTASK, mptr) != OK) panic("sys_copy can't send", NO_NUM);
+    /* Make this routine better.  Also check other guys' error handling -DEBUG */
+    mptr->m_type = SYS_COPY;
+    if (sendrec(SYSTASK, mptr) != OK)
+        panic("sys_copy can't send", NO_NUM);
 }
 
 PUBLIC sys_times(proc, ptr)
-int proc;			/* proc whose times are needed */
-real_time ptr[4];			/* pointer to time buffer */
+int proc;         /* proc whose times are needed */
+real_time ptr[4]; /* pointer to time buffer */
 {
-/* Fetch the accounting info for a proc. */
+    /* Fetch the accounting info for a proc. */
 
-  callm1(SYSTASK, SYS_TIMES, proc, 0, 0, ptr, NIL_PTR, NIL_PTR);
-  ptr[0] = M.USER_TIME;
-  ptr[1] = M.SYSTEM_TIME;
-  ptr[2] = M.CHILD_UTIME;
-  ptr[3] = M.CHILD_STIME;
+    callm1(SYSTASK, SYS_TIMES, proc, 0, 0, ptr, NIL_PTR, NIL_PTR);
+    ptr[0] = M.USER_TIME;
+    ptr[1] = M.SYSTEM_TIME;
+    ptr[2] = M.CHILD_UTIME;
+    ptr[3] = M.CHILD_STIME;
 }
 
+PUBLIC sys_abort() {
+    /* Something awful has happened.  Abandon ship. */
 
-
-
-
-PUBLIC sys_abort()
-{
-/* Something awful has happened.  Abandon ship. */
-
-  callm1(SYSTASK, SYS_ABORT, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    callm1(SYSTASK, SYS_ABORT, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }
-
 
 PUBLIC int tell_fs(what, p1, p2, p3)
 int what, p1, p2, p3;
 {
-/* This routine is only used by MM to inform FS of certain events:
- *      tell_fs(CHDIR, slot, dir, 0)
- *      tell_fs(EXIT, proc, 0, 0)
- *      tell_fs(FORK, parent, child, 0)
- *      tell_fs(SETGID, proc, realgid, effgid)
- *      tell_fs(SETUID, proc, realuid, effuid)
- *      tell_fs(SYNC, 0, 0, 0)
- *      tell_fs(UNPAUSE, proc, signr, 0)
- */
-  callm1(FS, what, p1, p2, p3, NIL_PTR, NIL_PTR, NIL_PTR);
+    /* This routine is only used by MM to inform FS of certain events:
+     *      tell_fs(CHDIR, slot, dir, 0)
+     *      tell_fs(EXIT, proc, 0, 0)
+     *      tell_fs(FORK, parent, child, 0)
+     *      tell_fs(SETGID, proc, realgid, effgid)
+     *      tell_fs(SETUID, proc, realuid, effuid)
+     *      tell_fs(SYNC, 0, 0, 0)
+     *      tell_fs(UNPAUSE, proc, signr, 0)
+     */
+    callm1(FS, what, p1, p2, p3, NIL_PTR, NIL_PTR, NIL_PTR);
 }


### PR DESCRIPTION
## Summary
- guard kernel headers against multiple inclusion
- modernize scanf wrappers with stdarg
- provide prototypes for kernel helpers and syscall impls
- update type definitions and syscall assembly for c90
- include missing headers in kernel

## Testing
- `cmake --build build` *(fails: floppy.c missing prototypes)*