### PR TITLE
Add attribute macros for portability

### DIFF
--- a/include/defs.h
+++ b/include/defs.h
@@ -2,17 +2,23 @@
 #define DEFS_H
 
 /* Custom fixed-width type definitions replacing <stdint.h>. */
+
+/* The compiler must provide builtin fixed width integer types. */
 #if defined(__clang__) || defined(__GNUC__)
 
-typedef __INT8_TYPE__ i8_t;
-typedef __UINT8_TYPE__ u8_t;
-typedef __INT16_TYPE__ i16_t;
-typedef __UINT16_TYPE__ u16_t;
-typedef __INT32_TYPE__ i32_t;
-typedef __UINT32_TYPE__ u32_t;
-typedef __INT64_TYPE__ i64_t;
-typedef __UINT64_TYPE__ u64_t;
-typedef __UINTPTR_TYPE__ uptr_t;
+typedef __INT8_TYPE__   i8_t;   /* signed 8  bit integer */
+typedef __UINT8_TYPE__  u8_t;   /* unsigned 8  bit integer */
+typedef __INT16_TYPE__  i16_t;  /* signed 16 bit integer */
+typedef __UINT16_TYPE__ u16_t;  /* unsigned 16 bit integer */
+typedef __INT32_TYPE__  i32_t;  /* signed 32 bit integer */
+typedef __UINT32_TYPE__ u32_t;  /* unsigned 32 bit integer */
+typedef __INT64_TYPE__  i64_t;  /* signed 64 bit integer */
+typedef __UINT64_TYPE__ u64_t;  /* unsigned 64 bit integer */
+typedef __UINTPTR_TYPE__ uptr_t; /* unsigned pointer sized integer */
+
+/* Attribute helpers usable in headers and source files. */
+#define PACKED __attribute__((packed)) /* structure packing */
+#define NAKED  __attribute__((naked))  /* naked function */
 
 #else
 #error "Unsupported compiler"

--- a/kernel/idt64.c
+++ b/kernel/idt64.c
@@ -16,12 +16,12 @@ struct idt_entry {
     u16_t offset_mid;
     u32_t offset_high;
     u32_t zero;
-} __attribute__((packed));
+} PACKED;
 
 struct idt_ptr {
     u16_t limit;
     u64_t base;
-} __attribute__((packed));
+} PACKED;
 
 struct tss64 {
     u32_t reserved0;
@@ -39,7 +39,7 @@ struct tss64 {
     u64_t reserved2;
     u16_t reserved3;
     u16_t io_map_base;
-} __attribute__((packed));
+} PACKED;
 
 /* Single shared interrupt stack. */
 static u8_t int_stack[4096];

--- a/kernel/mpx64.c
+++ b/kernel/mpx64.c
@@ -33,7 +33,7 @@ extern char k_stack[K_STACK_BYTES];
  *                              save                                         *
  *===========================================================================*/
 /* Save registers to the current process and switch stacks. */
-void save(void) __attribute__((naked));
+void save(void) NAKED;
 void save(void) {
     __asm__ volatile("push %%rax\n\t"
                      "push %%rbx\n\t"
@@ -102,7 +102,7 @@ void save(void) {
  *                              restart                                      *
  *===========================================================================*/
 /* Restore registers and continue the interrupted task. */
-void restart(void) __attribute__((naked));
+void restart(void) NAKED;
 void restart(void) {
     __asm__ volatile("movq _proc_ptr(%%rip), %%r15\n\t"
                      "movq %c0(%%r15), %%rsp\n\t"
@@ -136,7 +136,7 @@ void restart(void) {
  *                              isr_default                                  *
  *===========================================================================*/
 /* Default interrupt service routine. */
-void isr_default(void) __attribute__((naked));
+void isr_default(void) NAKED;
 void isr_default(void) {
     __asm__ volatile("call save\n\t"
                      "call _surprise\n\t"
@@ -147,7 +147,7 @@ void isr_default(void) {
  *                              isr_clock                                    *
  *===========================================================================*/
 /* Clock interrupt service routine. */
-void isr_clock(void) __attribute__((naked));
+void isr_clock(void) NAKED;
 void isr_clock(void) {
     __asm__ volatile("call save\n\t"
                      "call _clock_int\n\t"
@@ -158,7 +158,7 @@ void isr_clock(void) {
  *                              isr_keyboard                                 *
  *===========================================================================*/
 /* Keyboard interrupt service routine. */
-void isr_keyboard(void) __attribute__((naked));
+void isr_keyboard(void) NAKED;
 void isr_keyboard(void) {
     __asm__ volatile("call save\n\t"
                      "call _tty_int\n\t"
@@ -169,7 +169,7 @@ void isr_keyboard(void) {
  *                              s_call                                       *
  *===========================================================================*/
 /* System call entry point. */
-void s_call(void) __attribute__((naked));
+void s_call(void) NAKED;
 void s_call(void) {
     __asm__ volatile("call save\n\t"
                      "movq _proc_ptr(%rip), %rdi\n\t"
@@ -184,7 +184,7 @@ void s_call(void) {
  *                              lpr_int                                      *
  *===========================================================================*/
 /* Printer interrupt service routine. */
-void lpr_int(void) __attribute__((naked));
+void lpr_int(void) NAKED;
 void lpr_int(void) {
     __asm__ volatile("call save\n\t"
                      "call _pr_char\n\t"
@@ -195,7 +195,7 @@ void lpr_int(void) {
  *                              disk_int                                     *
  *===========================================================================*/
 /* Disk interrupt service routine. */
-void disk_int(void) __attribute__((naked));
+void disk_int(void) NAKED;
 void disk_int(void) {
     __asm__ volatile("call save\n\t"
                      "movq _int_mess+2(%rip), %rax\n\t"
@@ -208,7 +208,7 @@ void disk_int(void) {
  *                              divide                                       *
  *===========================================================================*/
 /* Divide trap handler. */
-void divide(void) __attribute__((naked));
+void divide(void) NAKED;
 void divide(void) {
     __asm__ volatile("call save\n\t"
                      "call _div_trap\n\t"
@@ -219,7 +219,7 @@ void divide(void) {
  *                              trp                                          *
  *===========================================================================*/
 /* General trap handler. */
-void trp(void) __attribute__((naked));
+void trp(void) NAKED;
 void trp(void) {
     __asm__ volatile("call save\n\t"
                      "call _trap\n\t"

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -35,7 +35,7 @@ void init_syscall_msrs(void) {
  *                              syscall_entry                                *
  *===========================================================================*/
 /* Entry point for user mode syscalls. */
-void syscall_entry(void) __attribute__((naked));
+void syscall_entry(void) NAKED;
 void syscall_entry(void) {
     __asm__ volatile("call save\n\t"
                      "mov %rdi, %rax\n\t"


### PR DESCRIPTION
## Summary
- introduce `PACKED` and `NAKED` macros for GCC attributes
- replace direct `__attribute__` uses in kernel sources

## Testing
- `cmake --build .`
- `make -C test f=test0` *(fails: missing separator)*