### PR TITLE
Use 64-bit typedefs

### DIFF
--- a/h/type.h
+++ b/h/type.h
@@ -1,6 +1,9 @@
 #ifndef TYPE_H
 #define TYPE_H
 
+/* Pull in the fixed-width integer typedefs. */
+#include "../include/defs.h"
+
 /* Macros */
 #define MAX(a, b) (a > b ? a : b)
 #define MIN(a, b) (a < b ? a : b)
@@ -33,8 +36,8 @@ typedef char links; /* number of links to an inode */
 typedef long real_time; /* real time in seconds since Jan 1, 1980 */
 typedef long file_pos;  /* position in, or length of, a file */
 #define MAX_FILE_POS 017777777777L
-typedef long long file_pos64; /* 64-bit file positions */
-#define MAX_FILE_POS64 0x7fffffffffffffffLL
+typedef i64_t file_pos64; /* 64-bit file positions */
+#define MAX_FILE_POS64 I64_C(0x7fffffffffffffff)
 typedef short int uid; /* user id */
 typedef char gid;      /* group id */
 

--- a/include/defs.h
+++ b/include/defs.h
@@ -14,6 +14,11 @@ typedef __INT64_TYPE__ i64_t;
 typedef __UINT64_TYPE__ u64_t;
 typedef __UINTPTR_TYPE__ uptr_t;
 
+/* Macros for defining 64-bit constants without littering the code with
+ * long long suffixes. */
+#define U64_C(val) val##ULL
+#define I64_C(val) val##LL
+
 #else
 #error "Unsupported compiler"
 #endif

--- a/include/paging.h
+++ b/include/paging.h
@@ -6,16 +6,16 @@
 
 /* Generic 4-level paging structures for 48-bit virtual addresses. */
 
-#define PAGE_SIZE_4K       4096
-#define PT_ENTRIES         512
+#define PAGE_SIZE_4K 4096
+#define PT_ENTRIES 512
 
 /* Page table entry flags */
-#define PT_PRESENT   0x001
-#define PT_WRITABLE  0x002
-#define PT_USER      0x004
+#define PT_PRESENT 0x001
+#define PT_WRITABLE 0x002
+#define PT_USER 0x004
 
-typedef unsigned long long phys_addr64;
-typedef unsigned long long virt_addr64;
+typedef u64_t phys_addr64;
+typedef u64_t virt_addr64;
 
 struct pt_entry {
     phys_addr64 addr;
@@ -40,7 +40,7 @@ struct pml4 {
 
 /* Kernel interfaces */
 void paging_init(void);
-void *alloc_virtual(unsigned long long bytes, int flags);
+void *alloc_virtual(u64_t bytes, int flags);
 int map_page(virt_addr64 va, phys_addr64 pa, int flags);
 
 #endif /* PAGING_H */

--- a/include/vm.h
+++ b/include/vm.h
@@ -1,18 +1,18 @@
 #ifndef VM_H
 #define VM_H
 
-#include "paging.h"
 #include "../h/const.h"
+#include "paging.h"
 
 /* Flags for virtual memory regions */
-#define VM_READ     0x1
-#define VM_WRITE    0x2
-#define VM_EXEC     0x4
-#define VM_PRIVATE  0x8
-#define VM_SHARED   0x10
-#define VM_ANON     0x20
+#define VM_READ 0x1
+#define VM_WRITE 0x2
+#define VM_EXEC 0x4
+#define VM_PRIVATE 0x8
+#define VM_SHARED 0x10
+#define VM_ANON 0x20
 
-#define VM_MAX_AREAS   16
+#define VM_MAX_AREAS 16
 
 struct vm_area {
     virt_addr64 start; /* inclusive start address */
@@ -26,9 +26,9 @@ struct vm_proc {
 };
 
 void vm_init(void);
-void *vm_alloc(unsigned long long bytes, int flags);
+void *vm_alloc(u64_t bytes, int flags);
 void vm_handle_fault(int proc, virt_addr64 addr);
 int vm_fork(int parent, int child);
-void *vm_mmap(int proc, void *addr, unsigned long long length, int flags);
+void *vm_mmap(int proc, void *addr, u64_t length, int flags);
 
 #endif /* VM_H */

--- a/kernel/paging.c
+++ b/kernel/paging.c
@@ -1,6 +1,6 @@
+#include "../include/paging.h"
 #include "const.h"
 #include "type.h"
-#include "../include/paging.h"
 
 /* Simple 4-level page table allocator used only for illustration. */
 
@@ -11,12 +11,12 @@ PRIVATE virt_addr64 next_kernel_va;
  *                              paging_init                                  *
  *===========================================================================*/
 /* Initialize kernel paging structures. */
-PUBLIC void paging_init(void)
-{
+PUBLIC void paging_init(void) {
     int i;
-    for (i = 0; i < PT_ENTRIES; i++) kernel_pml4.ptrs[i] = NIL_PTR;
+    for (i = 0; i < PT_ENTRIES; i++)
+        kernel_pml4.ptrs[i] = NIL_PTR;
     /* place kernel in higher half */
-    next_kernel_va = 0xffff800000000000ULL;
+    next_kernel_va = U64_C(0xffff800000000000);
 }
 
 /*===========================================================================*
@@ -26,8 +26,7 @@ PUBLIC void paging_init(void)
  * bytes: size in bytes.
  * flags: allocation flags (unused).
  */
-PUBLIC void *alloc_virtual(unsigned long long bytes, int flags)
-{
+PUBLIC void *alloc_virtual(u64_t bytes, int flags) {
     virt_addr64 va = next_kernel_va;
     unsigned long pages = (bytes + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
     next_kernel_va += pages * PAGE_SIZE_4K;
@@ -43,15 +42,16 @@ PUBLIC void *alloc_virtual(unsigned long long bytes, int flags)
  * pa: physical address to map to.
  * flags: mapping attributes (unused).
  */
-PUBLIC int map_page(virt_addr64 va, phys_addr64 pa, int flags)
-{
+PUBLIC int map_page(virt_addr64 va, phys_addr64 pa, int flags) {
     /* Mapping is not actually implemented.  We only preserve bookkeeping. */
     unsigned idx4 = (va >> 39) & 0x1FF;
     if (!kernel_pml4.ptrs[idx4]) {
-        kernel_pml4.ptrs[idx4] = (struct page_dir_ptr*) alloc_mem((sizeof(struct page_dir_ptr)+CLICK_SIZE-1)>>CLICK_SHIFT);
+        kernel_pml4.ptrs[idx4] = (struct page_dir_ptr *)alloc_mem(
+            (sizeof(struct page_dir_ptr) + CLICK_SIZE - 1) >> CLICK_SHIFT);
         memset(kernel_pml4.ptrs[idx4], 0, sizeof(struct page_dir_ptr));
     }
     /* Further levels would be allocated here in a complete system. */
-    (void)pa; (void)flags;
+    (void)pa;
+    (void)flags;
     return OK;
 }

--- a/mm/paging.c
+++ b/mm/paging.c
@@ -1,5 +1,5 @@
-#include "const.h"
 #include "../include/paging.h"
+#include "const.h"
 
 /* User space virtual address allocator using 4-level page tables. */
 
@@ -10,10 +10,9 @@ PRIVATE virt_addr64 next_user_va;
  *===========================================================================*/
 /* Initialize the user space paging allocator. */
 
-PUBLIC void mm_paging_init(void)
-{
+PUBLIC void mm_paging_init(void) {
     /* start at low canonical address */
-    next_user_va = 0x0000000000400000ULL;
+    next_user_va = U64_C(0x0000000000400000);
 }
 
 /*===========================================================================*
@@ -23,8 +22,7 @@ PUBLIC void mm_paging_init(void)
  * bytes: number of bytes requested.
  * flags: allocation flags (unused).
  */
-PUBLIC void *vm_alloc(unsigned long long bytes, int flags)
-{
+PUBLIC void *vm_alloc(u64_t bytes, int flags) {
     virt_addr64 va = next_user_va;
     unsigned long pages = (bytes + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
     next_user_va += pages * PAGE_SIZE_4K;

--- a/mm/vm.c
+++ b/mm/vm.c
@@ -1,5 +1,5 @@
-#include "const.h"
 #include "../include/vm.h"
+#include "const.h"
 #include "mproc.h"
 
 /*
@@ -20,8 +20,7 @@ PRIVATE unsigned long rng_state = 1;
 /* Generate a pseudo random number.
  * no parameters.
  */
-PRIVATE unsigned long next_rand(void)
-{
+PRIVATE unsigned long next_rand(void) {
     rng_state = rng_state * 1103515245 + 12345;
     return rng_state;
 }
@@ -32,8 +31,7 @@ PRIVATE unsigned long next_rand(void)
 /* Initialise the virtual memory subsystem.
  * no parameters.
  */
-PUBLIC void vm_init(void)
-{
+PUBLIC void vm_init(void) {
     int i;
     for (i = 0; i < NR_PROCS; i++) {
         vm_proc_table[i].area_count = 0;
@@ -48,13 +46,12 @@ PUBLIC void vm_init(void)
  * bytes: size in bytes to allocate.
  * flags: protection flags (unused).
  */
-PUBLIC void *vm_alloc(unsigned long long bytes, int flags)
-{
+PUBLIC void *vm_alloc(u64_t bytes, int flags) {
     virt_addr64 base;
     unsigned long pages;
 
     /* randomise base for a little ASLR */
-    base = 0x0000000010000000ULL + (next_rand() & 0xFFFFF000);
+    base = U64_C(0x0000000010000000) + (next_rand() & 0xFFFFF000);
     pages = (bytes + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
     (void)flags; /* protection flags unused in this stub */
     return (void *)(base + pages * PAGE_SIZE_4K);
@@ -67,8 +64,7 @@ PUBLIC void *vm_alloc(unsigned long long bytes, int flags)
  * proc: process index causing the fault.
  * addr: faulting virtual address.
  */
-PUBLIC void vm_handle_fault(int proc, virt_addr64 addr)
-{
+PUBLIC void vm_handle_fault(int proc, virt_addr64 addr) {
     /* This routine would allocate a page frame and map it.  Here it is
      * recorded only for bookkeeping.
      */
@@ -88,8 +84,7 @@ PUBLIC void vm_handle_fault(int proc, virt_addr64 addr)
  * parent: index of the parent process.
  * child: index of the child process.
  */
-PUBLIC int vm_fork(int parent, int child)
-{
+PUBLIC int vm_fork(int parent, int child) {
     vm_proc_table[child] = vm_proc_table[parent];
     return OK;
 }
@@ -103,8 +98,7 @@ PUBLIC int vm_fork(int parent, int child)
  * length: length of mapping in bytes.
  * flags:  mapping flags.
  */
-PUBLIC void *vm_mmap(int proc, void *addr, unsigned long long length, int flags)
-{
+PUBLIC void *vm_mmap(int proc, void *addr, u64_t length, int flags) {
     struct vm_proc *p = &vm_proc_table[proc];
     virt_addr64 base = (virt_addr64)addr;
 


### PR DESCRIPTION
## Summary
- add U64_C/I64_C helpers in defs.h
- use `u64_t`/`i64_t` in paging and VM code
- replace ULL/LL constants with macros

## Testing
- `make` *(fails: conflicting prototypes in perror.c)*