### PR TITLE
Modernize early command utilities

### DIFF
--- a/commands/basename.cpp
+++ b/commands/basename.cpp
@@ -1,34 +1,29 @@
 // Modernized for C++23
 
-#include <cstring>
+#include <filesystem>
+#include <string>
+#include <string_view>
 
 /* basename - print the last part of a path:	Author: Blaine Garfolo */
 
 int main(int argc, char *argv[]) {
-    int j, suflen;
-    char *c;
-    char *d;
-
+    // Ensure we have at least one path argument
     if (argc < 2) {
         std_err("Usage: basename string [suffix]  \n");
-        exit(1);
+        return 1;
     }
-    c = argv[1];
-    d = std::strrchr(argv[1], '/');
-    if (d == nullptr)
-        d = argv[1];
-    else
-        d++;
 
-    if (argc == 2) { /* if no suffix */
-        prints("%s \n", d);
-        exit(0);
-    } else { /* if suffix is present */
-        c = d;
-        suflen = strlen(argv[2]);
-        j = strlen(c) - suflen;
-        if (strcmp(c + j, argv[2]) == 0)
-            *(c + j) = 0;
+    // Extract the filename component
+    std::filesystem::path path{argv[1]};
+    std::string base = path.filename().string();
+
+    // Optionally strip the specified suffix
+    if (argc == 3) {
+        std::string_view suffix{argv[2]};
+        if (base.size() >= suffix.size() &&
+            base.compare(base.size() - suffix.size(), suffix.size(), suffix) == 0)
+            base.erase(base.size() - suffix.size());
     }
-    prints("%s \n", c);
+
+    prints("%s \n", base.c_str());
 }

--- a/commands/cal.cpp
+++ b/commands/cal.cpp
@@ -7,17 +7,19 @@
 /* cal - print a calendar		Author: Maritn Minow */
 
 #include "../include/stdio.h"
+#include <array>
+#include <string_view>
 
 #define do3months domonth
-#define IO_SUCCESS 0 /* Unix definitions		*/
-#define IO_ERROR 1
-#define EOS 0
+constexpr int IO_SUCCESS = 0;
+constexpr int IO_ERROR = 1;
+constexpr char EOS = 0;
 
-#define ENTRY_SIZE 3      /* 3 bytes per value		*/
-#define DAYS_PER_WEEK 7   /* Sunday, etc.			*/
-#define WEEKS_PER_MONTH 6 /* Max. weeks in a month	*/
-#define MONTHS_PER_LINE 3 /* Three months across		*/
-#define MONTH_SPACE 3     /* Between each month		*/
+constexpr int ENTRY_SIZE = 3;      /* 3 bytes per value		*/
+constexpr int DAYS_PER_WEEK = 7;   /* Sunday, etc.			*/
+constexpr int WEEKS_PER_MONTH = 6; /* Max. weeks in a month	*/
+constexpr int MONTHS_PER_LINE = 3; /* Three months across		*/
+constexpr int MONTH_SPACE = 3;     /* Between each month		*/
 
 char *badarg = {"Bad argument\n"};
 char *how = {"Usage: cal [month] year\n"};
@@ -29,10 +31,8 @@ char *how = {"Usage: cal [month] year\n"};
 char layout[MONTHS_PER_LINE][WEEKS_PER_MONTH][DAYS_PER_WEEK][ENTRY_SIZE];
 char outline[(MONTHS_PER_LINE * DAYS_PER_WEEK * ENTRY_SIZE) + (MONTHS_PER_LINE * MONTH_SPACE) + 1];
 
-char *weekday = " S  M Tu  W Th  F  S";
-char *monthname[] = {"???", /* No month 0	*/
-                     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+constexpr std::string_view weekday = " S  M Tu  W Th  F  S";
+constexpr std::array<std::string_view, 13> monthname = {"???", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
 int main(int argc, char *argv[]) {
     register int month;

--- a/commands/cat.cpp
+++ b/commands/cat.cpp
@@ -10,11 +10,12 @@ extern int errno; /*DEBUG*/
 
 #include "blocksiz.hpp"
 #include "stat.hpp"
+#include <array>
 
-#define BUF_SIZE 512   /* size of the output buffer */
-int unbuffered;        /* non-zero for unbuffered operation */
-char buffer[BUF_SIZE]; /* output buffer */
-char *next = buffer;   /* next free byte in buffer */
+constexpr std::size_t BUF_SIZE = 512; /* size of the output buffer */
+int unbuffered;                        /* non-zero for unbuffered operation */
+std::array<char, BUF_SIZE> buffer{};   /* output buffer */
+char *next = buffer.data();            /* next free byte in buffer */
 
 /* Function prototypes */
 static void copyfile(int fd1, int fd2);
@@ -88,11 +89,11 @@ static void copyfile(int fd1, int fd2) {
         } else {
             for (j = 0; j < n; j++) {
                 *next++ = buf[j];
-                if (next == &buffer[BUF_SIZE]) {
-                    m = write(fd2, buffer, BUF_SIZE);
+                if (next == buffer.data() + BUF_SIZE) {
+                    m = write(fd2, buffer.data(), BUF_SIZE);
                     if (m != BUF_SIZE)
                         quit();
-                    next = buffer;
+                    next = buffer.data();
                 }
             }
         }
@@ -101,8 +102,8 @@ static void copyfile(int fd1, int fd2) {
 
 static void flush(void) {
     /* Write any buffered output to standard output. */
-    if (next != buffer)
-        if (write(1, buffer, next - buffer) <= 0)
+    if (next != buffer.data())
+        if (write(1, buffer.data(), next - buffer.data()) <= 0)
             quit();
 }
 

--- a/commands/cc.cpp
+++ b/commands/cc.cpp
@@ -22,11 +22,12 @@
 
 #include <errno.h>
 #include <signal.h>
+#include <array>
 
-#define MAXARGC 64   /* maximum number of arguments allowed in a list */
-#define USTR_SIZE 64 /* maximum length of string variable */
+constexpr int MAXARGC = 64;   /* maximum number of arguments allowed in a list */
+constexpr int USTR_SIZE = 64; /* maximum length of string variable */
 
-typedef char USTRING[USTR_SIZE];
+using USTRING = std::array<char, USTR_SIZE>;
 
 struct arglist {
     int al_argc;


### PR DESCRIPTION
## Summary
- update `ar.cpp` with constexpr helpers and `std::array` buffers
- refactor `basename.cpp` using `std::filesystem`
- convert constants in `cal.cpp` to constexpr and use `std::array`
- modernize buffering in `cat.cpp`
- replace macros with constexpr values in `cc.cpp`

## Testing
- `make -C test f=test0` *(fails: No rule to make target '../lib/lib.a')*