### PR TITLE
Use C++17 headers in tests

### DIFF
--- a/tests/test_lib.cpp
+++ b/tests/test_lib.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert> // for assert
 
 /* Prototype for strlen from the Minix library. */
 int strlen(char *s);
@@ -10,9 +10,11 @@ int rand(void);
 /* Verify basic behavior of strlen, strcmp and rand. */
 int main(void) {
     /* strlen should count the characters in the string. */
-    assert(strlen("hello") == 5);
+    // Cast away const to match legacy prototypes.
+    assert(strlen(const_cast<char *>("hello")) == 5);
     /* strcmp should report equality for identical strings. */
-    assert(strcmp("a", "a") == 0);
+    // Legacy strcmp also expects mutable pointers.
+    assert(strcmp(const_cast<char *>("a"), const_cast<char *>("a")) == 0);
     /* rand should produce a non-negative value. */
     int r = rand();
     assert(r >= 0);

--- a/tests/test_syscall.cpp
+++ b/tests/test_syscall.cpp
@@ -1,6 +1,6 @@
-#include <assert.h>
+#include <cassert> // for assert
+#include <cstring> // for strcmp
 #include <fcntl.h>
-#include <string.h>
 #include <unistd.h>
 
 /* Exercise simple open/read/write/close syscalls. */
@@ -12,7 +12,8 @@ int main(void) {
     lseek(fd, 0, SEEK_SET);
     char buf[3] = {0};
     assert(read(fd, buf, 2) == 2);
-    assert(strcmp(buf, msg) == 0);
+    // Cast away const to match POSIX strcmp prototype.
+    assert(strcmp(buf, const_cast<char *>(msg)) == 0);
     close(fd);
     unlink("tempfile");
     return 0;


### PR DESCRIPTION
## Summary
- replace `assert.h` with `cassert`
- prefer C++ header wrappers in tests
- cast string literals to match C prototypes

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683a09ea0434833186275f582a846e25