### PR TITLE
Refactor IPC macros

### DIFF
--- a/fs/main.cpp
+++ b/fs/main.cpp
@@ -244,10 +244,10 @@ PRIVATE load_ram() {
 
     /* Tell RAM driver where RAM disk is and how big it is. */
     m1.m_type = DISK_IOCTL;
-    m1.DEVICE = RAM_DEV;
-    m1.POSITION = (long)init_org + (long)init_text_clicks + init_data_clicks;
-    m1.POSITION = m1.POSITION << CLICK_SHIFT;
-    m1.COUNT = count;
+    device(m1) = RAM_DEV;
+    position(m1) = (long)init_org + (long)init_text_clicks + init_data_clicks;
+    position(m1) = position(m1) << CLICK_SHIFT;
+    count(m1) = count;
     if (sendrec(MEM, &m1) != OK)
         panic("Can't report size to MEM", NO_NUM);
 

--- a/fs/misc.cpp
+++ b/fs/misc.cpp
@@ -237,7 +237,7 @@ PUBLIC int do_revive() {
 
     if (who > 0)
         return (ErrorCode::EPERM);
-    revive(m.REP_PROC_NR, m.REP_STATUS);
+    revive(rep_proc_nr(m), rep_status(m));
     dont_reply = TRUE; /* don't reply to the TTY task */
     return (OK);
 }

--- a/fs/pipe.cpp
+++ b/fs/pipe.cpp
@@ -251,13 +251,13 @@ PUBLIC int do_unpause() {
     if (task != XPIPE) {
         f = get_filp(rfp->fp_fd);
         dev = f->filp_ino->i_zone[0]; /* device on which proc is hanging */
-        mess.TTY_LINE = (dev >> MINOR) & BYTE;
-        mess.PROC_NR = proc_nr;
+        tty_line(mess) = (dev >> MINOR) & BYTE;
+        proc_nr(mess) = proc_nr;
         mess.m_type = CANCEL;
         if (sendrec(task, &mess) != OK)
             panic("unpause err 2", NO_NUM);
-        while (mess.REP_PROC_NR != proc_nr) {
-            revive(mess.REP_PROC_NR, mess.REP_STATUS);
+        while (rep_proc_nr(mess) != proc_nr) {
+            revive(rep_proc_nr(mess), rep_status(mess));
             if (receive(task, &m) != OK)
                 panic("unpause err 3", NO_NUM);
         }

--- a/fs/putc.cpp
+++ b/fs/putc.cpp
@@ -48,10 +48,10 @@ PRIVATE flush() {
     if (bufcount == 0)
         return;
     putchmsg.m_type = TTY_WRITE;
-    putchmsg.PROC_NR = 1;
-    putchmsg.TTY_LINE = 0;
-    putchmsg.ADDRESS = printbuf;
-    putchmsg.COUNT = bufcount;
+    proc_nr(putchmsg) = 1;
+    tty_line(putchmsg) = 0;
+    address(putchmsg) = printbuf;
+    count(putchmsg) = bufcount;
     sendrec(TTY, &putchmsg);
     bufcount = 0;
 }

--- a/h/com.hpp
+++ b/h/com.hpp
@@ -1,101 +1,103 @@
 #pragma once
 // Modernized for C++17
 
-/* System calls. */
-#define SEND 1               /* function code for sending messages */
-#define RECEIVE 2            /* function code for receiving messages */
-#define BOTH 3               /* function code for SEND + RECEIVE */
-#define ANY (NR_PROCS + 100) /* receive(ANY, buf) accepts from any source */
+/* System call function codes used with sendrec(). */
+inline constexpr int SEND = 1;             /* function code for sending messages */
+inline constexpr int RECEIVE = 2;          /* function code for receiving messages */
+inline constexpr int BOTH = 3;             /* function code for SEND + RECEIVE */
+inline constexpr int ANY = NR_PROCS + 100; /* receive(ANY, buf) accepts from any source */
 
 /* Task numbers, function codes and reply codes. */
-#define HARDWARE -1 /* used as source on interrupt generated msgs */
+inline constexpr int HARDWARE = -1; /* used as source on interrupt generated msgs */
 
-#define SYSTASK -2   /* internal functions */
-#define SYS_XIT 1    /* fcn code for sys_xit(parent, proc) */
-#define SYS_GETSP 2  /* fcn code for sys_sp(proc, &new_sp) */
-#define SYS_SIG 3    /* fcn code for sys_sig(proc, sig) */
-#define SYS_FORK 4   /* fcn code for sys_fork(parent, child) */
-#define SYS_NEWMAP 5 /* fcn code for sys_newmap(procno, map_ptr) */
-#define SYS_COPY 6   /* fcn code for sys_copy(ptr) */
-#define SYS_EXEC 7   /* fcn code for sys_exec(procno, new_sp) */
-#define SYS_TIMES 8  /* fcn code for sys_times(procno, bufptr) */
-#define SYS_ABORT 9  /* fcn code for sys_abort() */
+inline constexpr int SYSTASK = -2;   /* internal functions */
+inline constexpr int SYS_XIT = 1;    /* fcn code for sys_xit(parent, proc) */
+inline constexpr int SYS_GETSP = 2;  /* fcn code for sys_sp(proc, &new_sp) */
+inline constexpr int SYS_SIG = 3;    /* fcn code for sys_sig(proc, sig) */
+inline constexpr int SYS_FORK = 4;   /* fcn code for sys_fork(parent, child) */
+inline constexpr int SYS_NEWMAP = 5; /* fcn code for sys_newmap(procno, map_ptr) */
+inline constexpr int SYS_COPY = 6;   /* fcn code for sys_copy(ptr) */
+inline constexpr int SYS_EXEC = 7;   /* fcn code for sys_exec(procno, new_sp) */
+inline constexpr int SYS_TIMES = 8;  /* fcn code for sys_times(procno, bufptr) */
+inline constexpr int SYS_ABORT = 9;  /* fcn code for sys_abort() */
 
-#define CLOCK -3     /* clock class */
-#define SET_ALARM 1  /* fcn code to CLOCK, set up alarm */
-#define CLOCK_TICK 2 /* fcn code for clock tick */
-#define GET_TIME 3   /* fcn code to CLOCK, get real time */
-#define SET_TIME 4   /* fcn code to CLOCK, set real time */
-#define REAL_TIME 1  /* reply from CLOCK: here is real time */
+inline constexpr int CLOCK = -3;     /* clock class */
+inline constexpr int SET_ALARM = 1;  /* fcn code to CLOCK, set up alarm */
+inline constexpr int CLOCK_TICK = 2; /* fcn code for clock tick */
+inline constexpr int GET_TIME = 3;   /* fcn code to CLOCK, get real time */
+inline constexpr int SET_TIME = 4;   /* fcn code to CLOCK, set real time */
+inline constexpr int REAL_TIME = 1;  /* reply from CLOCK: here is real time */
 
-#define MEM -4     /* /dev/ram, /dev/(k)mem and /dev/null class */
-#define RAM_DEV 0  /* minor device for /dev/ram */
-#define MEM_DEV 1  /* minor device for /dev/mem */
-#define KMEM_DEV 2 /* minor device for /dev/kmem */
-#define NULL_DEV 3 /* minor device for /dev/null */
+inline constexpr int MEM = -4;     /* /dev/ram, /dev/(k)mem and /dev/null class */
+inline constexpr int RAM_DEV = 0;  /* minor device for /dev/ram */
+inline constexpr int MEM_DEV = 1;  /* minor device for /dev/mem */
+inline constexpr int KMEM_DEV = 2; /* minor device for /dev/kmem */
+inline constexpr int NULL_DEV = 3; /* minor device for /dev/null */
 
-#define FLOPPY -5     /* floppy disk class */
-#define WINCHESTER -6 /* winchester (hard) disk class */
-#define DISKINT 1     /* fcn code for disk interupt */
-#define DISK_READ 3   /* fcn code to DISK (must equal TTY_READ) */
-#define DISK_WRITE 4  /* fcn code to DISK (must equal TTY_WRITE) */
-#define DISK_IOCTL 5  /* fcn code for setting up RAM disk */
+inline constexpr int FLOPPY = -5;     /* floppy disk class */
+inline constexpr int WINCHESTER = -6; /* winchester (hard) disk class */
+inline constexpr int DISKINT = 1;     /* fcn code for disk interrupt */
+inline constexpr int DISK_READ = 3;   /* fcn code to DISK (must equal TTY_READ) */
+inline constexpr int DISK_WRITE = 4;  /* fcn code to DISK (must equal TTY_WRITE) */
+inline constexpr int DISK_IOCTL = 5;  /* fcn code for setting up RAM disk */
 
-#define TTY -7         /* terminal I/O class */
-#define PRINTER -8     /* printer  I/O class */
-#define TTY_CHAR_INT 1 /* fcn code for tty input interrupt */
-#define TTY_O_DONE 2   /* fcn code for tty output done */
-#define TTY_READ 3     /* fcn code for reading from tty */
-#define TTY_WRITE 4    /* fcn code for writing to tty */
-#define TTY_IOCTL 5    /* fcn code for ioctl */
-#define SUSPEND -998   /* used in interrupts when tty has no data */
+inline constexpr int TTY = -7;         /* terminal I/O class */
+inline constexpr int PRINTER = -8;     /* printer I/O class */
+inline constexpr int TTY_CHAR_INT = 1; /* fcn code for tty input interrupt */
+inline constexpr int TTY_O_DONE = 2;   /* fcn code for tty output done */
+inline constexpr int TTY_READ = 3;     /* fcn code for reading from tty */
+inline constexpr int TTY_WRITE = 4;    /* fcn code for writing to tty */
+inline constexpr int TTY_IOCTL = 5;    /* fcn code for ioctl */
+inline constexpr int SUSPEND = -998;   /* used in interrupts when tty has no data */
 
-/* Names of message fields for messages to CLOCK task. */
-#define DELTA_TICKS m6_l1   /* alarm interval in clock ticks */
-#define FUNC_TO_CALL m6_f1  /* pointer to function to call */
-#define NEW_TIME m6_l1      /* value to set clock to (SET_TIME) */
-#define CLOCK_PROC_NR m6_i1 /* which proc (or task) wants the alarm? */
-#define SECONDS_LEFT m6_l1  /* how many seconds were remaining */
+/* Accessors for messages sent to the CLOCK task. */
+inline long &delta_ticks(message &m) { return m.m6_l1; }  /* alarm interval in clock ticks */
+inline auto &func_to_call(message &m) { return m.m6_f1; } /* pointer to function to call */
+inline long &new_time(message &m) { return m.m6_l1; }     /* value to set clock to (SET_TIME) */
+inline int &clock_proc_nr(message &m) {
+    return m.m6_i1;
+} /* which proc (or task) wants the alarm? */
+inline long &seconds_left(message &m) { return m.m6_l1; } /* how many seconds were remaining */
 
-/* Names of message fields used for messages to block and character tasks. */
-#define DEVICE m2_i1   /* major-minor device */
-#define PROC_NR m2_i2  /* which (proc) wants I/O? */
-#define COUNT m2_i3    /* how many bytes to transfer */
-#define POSITION m2_l1 /* file offset */
-#define ADDRESS m2_p1  /* core buffer address */
+/* Accessors for block and character task messages. */
+inline int &device(message &m) { return m.m2_i1; }    /* major-minor device */
+inline int &proc_nr(message &m) { return m.m2_i2; }   /* which (proc) wants I/O? */
+inline int &count(message &m) { return m.m2_i3; }     /* how many bytes to transfer */
+inline long &position(message &m) { return m.m2_l1; } /* file offset */
+inline char *&address(message &m) { return m.m2_p1; } /* core buffer address */
 
-/* Names of message fields for messages to TTY task. */
-#define TTY_LINE m2_i1    /* message parameter: terminal line */
-#define TTY_REQUEST m2_i3 /* message parameter: ioctl request code */
-#define TTY_SPEK m2_l1    /* message parameter: ioctl speed, erasing */
-#define TTY_FLAGS m2_l2   /* message parameter: ioctl tty mode */
+/* Accessors for TTY task messages. */
+inline int &tty_line(message &m) { return m.m2_i1; }    /* terminal line */
+inline int &tty_request(message &m) { return m.m2_i3; } /* ioctl request code */
+inline long &tty_spek(message &m) { return m.m2_l1; }   /* ioctl speed, erasing */
+inline long &tty_flags(message &m) { return m.m2_l2; }  /* ioctl tty mode */
 
-/* Names of messages fields used in reply messages from tasks. */
-#define REP_PROC_NR m2_i1 /* # of proc on whose behalf I/O was done */
-#define REP_STATUS m2_i2  /* bytes transferred or error number */
+/* Accessors for reply messages from tasks. */
+inline int &rep_proc_nr(message &m) { return m.m2_i1; } /* proc for which I/O was done */
+inline int &rep_status(message &m) { return m.m2_i2; }  /* bytes transferred or error */
 
-/* Names of fields for copy message to SYSTASK. */
-#define SRC_SPACE m5_c1   /* T or D space (stack is also D) */
-#define SRC_PROC_NR m5_i1 /* process to copy from */
-#define SRC_BUFFER m5_l1  /* virtual address where data come from */
-#define DST_SPACE m5_c2   /* T or D space (stack is also D) */
-#define DST_PROC_NR m5_i2 /* process to copy to */
-#define DST_BUFFER m5_l2  /* virtual address where data go to */
-#define COPY_BYTES m5_l3  /* number of bytes to copy */
+/* Accessors for SYSTASK copy messages. */
+inline char &src_space(message &m) { return m.m5_c1; }  /* T or D space */
+inline int &src_proc_nr(message &m) { return m.m5_i1; } /* process to copy from */
+inline long &src_buffer(message &m) { return m.m5_l1; } /* virtual address source */
+inline char &dst_space(message &m) { return m.m5_c2; }  /* T or D space */
+inline int &dst_proc_nr(message &m) { return m.m5_i2; } /* process to copy to */
+inline long &dst_buffer(message &m) { return m.m5_l2; } /* virtual address dest */
+inline long &copy_bytes(message &m) { return m.m5_l3; } /* number of bytes to copy */
 
-/* Field names for accounting, SYSTASK and miscellaneous. */
-#define USER_TIME m4_l1   /* user time consumed by process */
-#define SYSTEM_TIME m4_l2 /* system time consumed by process */
-#define CHILD_UTIME m4_l3 /* user time consumed by process' children */
-#define CHILD_STIME m4_l4 /* system time consumed by proces children */
+/* Accessors for accounting and miscellaneous fields. */
+inline long &user_time(message &m) { return m.m4_l1; }   /* user time consumed */
+inline long &system_time(message &m) { return m.m4_l2; } /* system time consumed */
+inline long &child_utime(message &m) { return m.m4_l3; } /* user time of children */
+inline long &child_stime(message &m) { return m.m4_l4; } /* system time of children */
 
-#define PROC1 m1_i1     /* indicates a process */
-#define PROC2 m1_i2     /* indicates a process */
-#define PID m1_i3       /* process id passed from MM to kernel */
-#define STACK_PTR m1_p1 /* used for stack ptr in sys_exec, sys_getsp */
-#define PR m6_i1        /* process number for sys_sig */
-#define SIGNUM m6_i2    /* signal number for sys_sig */
-#define FUNC m6_f1      /* function pointer for sys_sig */
-#define MEM_PTR m1_p1   /* tells where memory map is for sys_newmap */
-#define CANCEL 0        /* general request to force a task to cancel */
-#define SIG_MAP m1_i2   /* used by kernel for passing signal bit map */
+inline int &proc1(message &m) { return m.m1_i1; }       /* indicates a process */
+inline int &proc2(message &m) { return m.m1_i2; }       /* indicates a process */
+inline int &pid(message &m) { return m.m1_i3; }         /* process id passed from MM */
+inline char *&stack_ptr(message &m) { return m.m1_p1; } /* stack pointer */
+inline int &pr(message &m) { return m.m6_i1; }          /* process number for sys_sig */
+inline int &signum(message &m) { return m.m6_i2; }      /* signal number for sys_sig */
+inline auto &func(message &m) { return m.m6_f1; }       /* function pointer for sys_sig */
+inline char *&mem_ptr(message &m) { return m.m1_p1; }   /* memory map pointer */
+inline constexpr int CANCEL = 0;                        /* request to cancel */
+inline int &sig_map(message &m) { return m.m1_i2; }     /* signal bit map */

--- a/kernel/at_wini.cpp
+++ b/kernel/at_wini.cpp
@@ -108,7 +108,7 @@ PUBLIC winchester_task() {
             continue;
         }
         caller = w_mess.m_source;
-        proc_nr = w_mess.PROC_NR;
+        proc_nr = proc_nr(w_mess);
 
         /* Now carry out the work. */
         switch (w_mess.m_type) {
@@ -123,10 +123,10 @@ PUBLIC winchester_task() {
 
         /* Finally, prepare and send the reply message. */
         w_mess.m_type = TASK_REPLY;
-        w_mess.REP_PROC_NR = proc_nr;
+        rep_proc_nr(w_mess) = proc_nr;
 
-        w_mess.REP_STATUS = r; /* # of bytes transferred or error code */
-        send(caller, &w_mess); /* send reply to caller */
+        rep_status(w_mess) = r; /* # of bytes transferred or error code */
+        send(caller, &w_mess);  /* send reply to caller */
     }
 }
 
@@ -161,9 +161,9 @@ message *m_ptr; /* pointer to read or write w_message */
     wn->wn_cylinder = sector / (wn->wn_heads * wn->wn_maxsec);
     wn->wn_sector = (sector % wn->wn_maxsec) + 1;
     wn->wn_head = (sector % (wn->wn_heads * wn->wn_maxsec)) / wn->wn_maxsec;
-    wn->wn_count = m_ptr->COUNT;
-    wn->wn_address = (vir_bytes)m_ptr->ADDRESS;
-    wn->wn_procnr = m_ptr->PROC_NR;
+    wn->wn_count = count(*m_ptr);
+    wn->wn_address = (vir_bytes)address(*m_ptr);
+    wn->wn_procnr = proc_nr(*m_ptr);
 
     /* This loop allows a failed operation to be repeated. */
     while (errors <= MAX_ERRORS) {
@@ -443,11 +443,11 @@ PRIVATE init_params() {
 
     /* Read the partition table for each drive and save them */
     for (i = 0; i < nr_drives; i++) {
-        w_mess.DEVICE = i * 5;
-        w_mess.POSITION = 0L;
-        w_mess.COUNT = BLOCK_SIZE;
-        w_mess.ADDRESS = (char *)buf;
-        w_mess.PROC_NR = WINCHESTER;
+        device(w_mess) = i * 5;
+        position(w_mess) = 0L;
+        count(w_mess) = BLOCK_SIZE;
+        address(w_mess) = (char *)buf;
+        proc_nr(w_mess) = WINCHESTER;
         w_mess.m_type = DISK_READ;
         if (w_do_rdwt(&w_mess) != BLOCK_SIZE)
             panic("Can't read partition table of winchester ", i);

--- a/kernel/floppy.cpp
+++ b/kernel/floppy.cpp
@@ -169,7 +169,7 @@ PUBLIC floppy_task() {
         if (mess.m_source < 0)
             panic("disk task got message from ", mess.m_source);
         caller = mess.m_source;
-        proc_nr = mess.PROC_NR;
+        proc_nr = proc_nr(mess);
 
         /* Now carry out the work. */
         switch (mess.m_type) {
@@ -186,9 +186,9 @@ PUBLIC floppy_task() {
 
         /* Finally, prepare and send the reply message. */
         mess.m_type = TASK_REPLY;
-        mess.REP_PROC_NR = proc_nr;
-        mess.REP_STATUS = r; /* # of bytes transferred or error code */
-        send(caller, &mess); /* send reply to caller */
+        rep_proc_nr(mess) = proc_nr;
+        rep_status(mess) = r; /* # of bytes transferred or error code */
+        send(caller, &mess);  /* send reply to caller */
     }
 }
 
@@ -218,9 +218,9 @@ PRIVATE int do_rdwt(message *m_ptr) {
     fp->fl_cylinder = (int)(block / (NR_HEADS * nr_sectors[d]));
     fp->fl_sector = (int)interleave[block % nr_sectors[d]];
     fp->fl_head = (int)(block % (NR_HEADS * nr_sectors[d])) / nr_sectors[d];
-    fp->fl_count = m_ptr->COUNT;
-    fp->fl_address = (vir_bytes)m_ptr->ADDRESS;
-    fp->fl_procnr = m_ptr->PROC_NR;
+    fp->fl_count = count(*m_ptr);
+    fp->fl_address = (vir_bytes)address(*m_ptr);
+    fp->fl_procnr = proc_nr(*m_ptr);
     if (fp->fl_count != BLOCK_SIZE)
         return (ErrorCode::EINVAL);
 
@@ -624,9 +624,9 @@ PRIVATE reset() {
 PRIVATE void clock_mess(int ticks, void (*func)(void)) {
     /* Send the clock task a message. */
     mess.m_type = SET_ALARM;
-    mess.CLOCK_PROC_NR = FLOPPY;
-    mess.DELTA_TICKS = ticks;
-    mess.FUNC_TO_CALL = func;
+    clock_proc_nr(mess) = FLOPPY;
+    delta_ticks(mess) = ticks;
+    func_to_call(mess) = func;
     sendrec(CLOCK, &mess);
 }
 

--- a/kernel/memory.cpp
+++ b/kernel/memory.cpp
@@ -61,7 +61,7 @@ PUBLIC mem_task() {
         if (mess.m_source < 0)
             panic("mem task got message from ", mess.m_source);
         caller = mess.m_source;
-        proc_nr = mess.PROC_NR;
+        proc_nr = proc_nr(mess);
 
         /* Now carry out the work.  It depends on the opcode. */
         switch (mess.m_type) {
@@ -81,8 +81,8 @@ PUBLIC mem_task() {
 
         /* Finally, prepare and send the reply message. */
         mess.m_type = TASK_REPLY;
-        mess.REP_PROC_NR = proc_nr;
-        mess.REP_STATUS = r;
+        rep_proc_nr(mess) = proc_nr;
+        rep_status(mess) = r;
         send(caller, &mess);
     }
 }
@@ -114,13 +114,13 @@ register message *m_ptr; /* pointer to read or write message */
     mem_phys = ram_origin[device] + m_ptr->POSITION;
     if (mem_phys >= ram_limit[device])
         return (EOF);
-    count = m_ptr->COUNT;
+    count = count(*m_ptr);
     if (mem_phys + count > ram_limit[device])
         count = ram_limit[device] - mem_phys;
 
     /* Determine address where data is to go or to come from. */
-    rp = proc_addr(m_ptr->PROC_NR);
-    user_phys = umap(rp, D, (vir_bytes)m_ptr->ADDRESS, (vir_bytes)count);
+    rp = proc_addr(proc_nr(*m_ptr));
+    user_phys = umap(rp, D, (vir_bytes)address(*m_ptr), (vir_bytes)count);
     if (user_phys == 0)
         return (ErrorCode::E_BAD_ADDR);
 

--- a/kernel/printer.cpp
+++ b/kernel/printer.cpp
@@ -200,10 +200,10 @@ int status;  /* number of  chars printed or error code */
 
     message pr_mess;
 
-    pr_mess.m_type = code;         /* TASK_REPLY or REVIVE */
-    pr_mess.REP_STATUS = status;   /* count or ErrorCode::EIO */
-    pr_mess.REP_PROC_NR = process; /* which user does this pertain to */
-    send(replyee, &pr_mess);       /* send the message */
+    pr_mess.m_type = code;          /* TASK_REPLY or REVIVE */
+    rep_status(pr_mess) = status;   /* count or ErrorCode::EIO */
+    rep_proc_nr(pr_mess) = process; /* which user does this pertain to */
+    send(replyee, &pr_mess);        /* send the message */
 }
 
 /*===========================================================================*
@@ -281,6 +281,6 @@ PUBLIC pr_char() {
 
     /* Count is 0 or an error occurred; send message to printer task. */
     int_mess.m_type = TTY_O_DONE;
-    int_mess.REP_STATUS = (pcount == 0 ? OK : value);
+    rep_status(int_mess) = (pcount == 0 ? OK : value);
     interrupt(PRINTER, &int_mess);
 }

--- a/kernel/wini.cpp
+++ b/kernel/wini.cpp
@@ -134,7 +134,7 @@ PUBLIC winchester_task() {
             continue;
         }
         caller = w_mess.m_source;
-        proc_nr = w_mess.PROC_NR;
+        proc_nr = proc_nr(w_mess);
 
         /* Now carry out the work. */
         switch (w_mess.m_type) {
@@ -149,10 +149,10 @@ PUBLIC winchester_task() {
 
         /* Finally, prepare and send the reply message. */
         w_mess.m_type = TASK_REPLY;
-        w_mess.REP_PROC_NR = proc_nr;
+        rep_proc_nr(w_mess) = proc_nr;
 
-        w_mess.REP_STATUS = r; /* # of bytes transferred or error code */
-        send(caller, &w_mess); /* send reply to caller */
+        rep_status(w_mess) = r; /* # of bytes transferred or error code */
+        send(caller, &w_mess);  /* send reply to caller */
     }
 }
 
@@ -607,11 +607,11 @@ static void init_params() {
 
     /* Read the partition table for each drive and save them */
     for (i = 0; i < nr_drives; i++) {
-        w_mess.DEVICE = i * 5;
-        w_mess.POSITION = 0L;
-        w_mess.COUNT = BLOCK_SIZE;
-        w_mess.ADDRESS = (char *)buf;
-        w_mess.PROC_NR = WINCHESTER;
+        device(w_mess) = i * 5;
+        position(w_mess) = 0L;
+        count(w_mess) = BLOCK_SIZE;
+        address(w_mess) = (char *)buf;
+        proc_nr(w_mess) = WINCHESTER;
         w_mess.m_type = DISK_READ;
         if (w_do_rdwt(&w_mess) != BLOCK_SIZE)
             panic("Can't read partition table of winchester ", i);

--- a/kernel/xt_wini.cpp
+++ b/kernel/xt_wini.cpp
@@ -127,7 +127,7 @@ PUBLIC winchester_task() {
             continue;
         }
         caller = w_mess.m_source;
-        proc_nr = w_mess.PROC_NR;
+        proc_nr = proc_nr(w_mess);
 
         /* Now carry out the work. */
         switch (w_mess.m_type) {
@@ -142,10 +142,10 @@ PUBLIC winchester_task() {
 
         /* Finally, prepare and send the reply message. */
         w_mess.m_type = TASK_REPLY;
-        w_mess.REP_PROC_NR = proc_nr;
+        rep_proc_nr(w_mess) = proc_nr;
 
-        w_mess.REP_STATUS = r; /* # of bytes transferred or error code */
-        send(caller, &w_mess); /* send reply to caller */
+        rep_status(w_mess) = r; /* # of bytes transferred or error code */
+        send(caller, &w_mess);  /* send reply to caller */
     }
 }
 
@@ -180,9 +180,9 @@ message *m_ptr; /* pointer to read or write w_message */
     wn->wn_cylinder = sector / (wn->wn_heads * NR_SECTORS);
     wn->wn_sector = (sector % NR_SECTORS);
     wn->wn_head = (sector % (wn->wn_heads * NR_SECTORS)) / NR_SECTORS;
-    wn->wn_count = m_ptr->COUNT;
-    wn->wn_address = (vir_bytes)m_ptr->ADDRESS;
-    wn->wn_procnr = m_ptr->PROC_NR;
+    wn->wn_count = count(*m_ptr);
+    wn->wn_address = (vir_bytes)address(*m_ptr);
+    wn->wn_procnr = proc_nr(*m_ptr);
 
     /* This loop allows a failed operation to be repeated. */
     while (errors <= MAX_ERRORS) {
@@ -606,11 +606,11 @@ PRIVATE init_params() {
 
     /* Read the partition table for each drive and save them */
     for (i = 0; i < nr_drives; i++) {
-        w_mess.DEVICE = i * 5;
-        w_mess.POSITION = 0L;
-        w_mess.COUNT = BLOCK_SIZE;
-        w_mess.ADDRESS = (char *)buf;
-        w_mess.PROC_NR = WINCHESTER;
+        device(w_mess) = i * 5;
+        position(w_mess) = 0L;
+        count(w_mess) = BLOCK_SIZE;
+        address(w_mess) = (char *)buf;
+        proc_nr(w_mess) = WINCHESTER;
         w_mess.m_type = DISK_READ;
         if (w_do_rdwt(&w_mess) != BLOCK_SIZE)
             panic("Can't read partition table of winchester ", i);

--- a/lib/access.cpp
+++ b/lib/access.cpp
@@ -1,8 +1,3 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int access(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, ACCESS, mode, name);
-}
+PUBLIC int access(char *name, int mode) { return callm3(FS, ACCESS, mode, name); }

--- a/lib/ioctl.cpp
+++ b/lib/ioctl.cpp
@@ -14,15 +14,15 @@ union {
     int n;
     long erase, kill, intr, quit, xon, xoff, eof, brk;
 
-    M.TTY_REQUEST = request;
-    M.TTY_LINE = fd;
+    tty_request(M) = request;
+    tty_line(M) = fd;
 
     switch (request) {
     case TIOCSETP:
         erase = u.argp->sg_erase & 0377;
         kill = u.argp->sg_kill & 0377;
-        M.TTY_SPEK = (erase << 8) | kill;
-        M.TTY_FLAGS = u.argp->sg_flags;
+        tty_spek(M) = (erase << 8) | kill;
+        tty_flags(M) = u.argp->sg_flags;
         n = callx(FS, IOCTL);
         return (n);
 
@@ -33,26 +33,26 @@ union {
         xoff = u.argt->t_stopc & 0377;
         eof = u.argt->t_eofc & 0377;
         brk = u.argt->t_brkc & 0377; /* not used at the moment */
-        M.TTY_SPEK = (intr << 24) | (quit << 16) | (xon << 8) | (xoff << 0);
-        M.TTY_FLAGS = (eof << 8) | (brk << 0);
+        tty_spek(M) = (intr << 24) | (quit << 16) | (xon << 8) | (xoff << 0);
+        tty_flags(M) = (eof << 8) | (brk << 0);
         n = callx(FS, IOCTL);
         return (n);
 
     case TIOCGETP:
         n = callx(FS, IOCTL);
-        u.argp->sg_erase = (M.TTY_SPEK >> 8) & 0377;
-        u.argp->sg_kill = (M.TTY_SPEK >> 0) & 0377;
-        u.argp->sg_flags = M.TTY_FLAGS;
+        u.argp->sg_erase = (tty_spek(M) >> 8) & 0377;
+        u.argp->sg_kill = (tty_spek(M) >> 0) & 0377;
+        u.argp->sg_flags = tty_flags(M);
         return (n);
 
     case TIOCGETC:
         n = callx(FS, IOCTL);
-        u.argt->t_intrc = (M.TTY_SPEK >> 24) & 0377;
-        u.argt->t_quitc = (M.TTY_SPEK >> 16) & 0377;
-        u.argt->t_startc = (M.TTY_SPEK >> 8) & 0377;
-        u.argt->t_stopc = (M.TTY_SPEK >> 0) & 0377;
-        u.argt->t_eofc = (M.TTY_FLAGS >> 8) & 0377;
-        u.argt->t_brkc = (M.TTY_FLAGS >> 8) & 0377;
+        u.argt->t_intrc = (tty_spek(M) >> 24) & 0377;
+        u.argt->t_quitc = (tty_spek(M) >> 16) & 0377;
+        u.argt->t_startc = (tty_spek(M) >> 8) & 0377;
+        u.argt->t_stopc = (tty_spek(M) >> 0) & 0377;
+        u.argt->t_eofc = (tty_flags(M) >> 8) & 0377;
+        u.argt->t_brkc = (tty_flags(M) >> 8) & 0377;
         return (n);
 
     default:

--- a/mm/putc.cpp
+++ b/mm/putc.cpp
@@ -3,16 +3,16 @@
  * Printing is done by calling the TTY task directly, not going through FS.
  */
 
+#include "../h/com.h"
 #include "../h/const.h"
 #include "../h/type.h"
-#include "../h/com.h"
 
-#define STD_OUTPUT          1	/* file descriptor for standard output */
-#define BUF_SIZE          100	/* print buffer size */
+#define STD_OUTPUT 1 /* file descriptor for standard output */
+#define BUF_SIZE 100 /* print buffer size */
 
-PRIVATE int buf_count;		/* # characters in the buffer */
-PRIVATE char print_buf[BUF_SIZE];	/* output is buffered here */
-PRIVATE message putch_msg;	/* used for message to TTY task */
+PRIVATE int buf_count;            /* # characters in the buffer */
+PRIVATE char print_buf[BUF_SIZE]; /* output is buffered here */
+PRIVATE message putch_msg;        /* used for message to TTY task */
 
 /*===========================================================================*
  *				putc					     *
@@ -21,26 +21,27 @@ PUBLIC putc(c)
 char c;
 {
 
-  /* Accumulate another character.  If '\n' or buffer full, print it. */
-  print_buf[buf_count++] = c;
-  if (buf_count == BUF_SIZE) F_l_u_s_h();
-  if (c == '\n')  F_l_u_s_h();
+    /* Accumulate another character.  If '\n' or buffer full, print it. */
+    print_buf[buf_count++] = c;
+    if (buf_count == BUF_SIZE)
+        F_l_u_s_h();
+    if (c == '\n')
+        F_l_u_s_h();
 }
-
 
 /*===========================================================================*
  *				F_l_u_s_h				     *
  *===========================================================================*/
-PRIVATE F_l_u_s_h()
-{
-/* Flush the print buffer by calling TTY task. */
+PRIVATE F_l_u_s_h() {
+    /* Flush the print buffer by calling TTY task. */
 
-  if (buf_count == 0) return;
-  putch_msg.m_type = TTY_WRITE;
-  putch_msg.PROC_NR  = 0;
-  putch_msg.TTY_LINE = 0;
-  putch_msg.ADDRESS  = print_buf;
-  putch_msg.COUNT = buf_count;
-  sendrec(TTY, &putch_msg);
-  buf_count = 0;
+    if (buf_count == 0)
+        return;
+    putch_msg.m_type = TTY_WRITE;
+    proc_nr(putch_msg) = 0;
+    tty_line(putch_msg) = 0;
+    address(putch_msg) = print_buf;
+    count(putch_msg) = buf_count;
+    sendrec(TTY, &putch_msg);
+    buf_count = 0;
 }

--- a/mm/signal.cpp
+++ b/mm/signal.cpp
@@ -92,12 +92,12 @@ PUBLIC int do_ksig() {
     if (who != HARDWARE && who != FS_PROC_NR)
         return (ErrorCode::EPERM);
 
-    proc_nr = mm_in.PROC1;
+    proc_nr = proc1(mm_in);
     rmp = &mproc[proc_nr];
     if ((rmp->mp_flags & IN_USE) == 0 || (rmp->mp_flags & HANGING))
         return (OK);
     proc_id = rmp->mp_pid;
-    sig_map = (unshort)mm_in.SIG_MAP;
+    sig_map = (unshort)sig_map(mm_in);
     mp = &mproc[0]; /* pretend kernel signals are from MM */
 
     /* Stack faults are passed from kernel to MM as pseudo-signal 16. */
@@ -262,8 +262,8 @@ unsigned sec; /* how many seconds delay before the signal */
     int remaining;
 
     m_sig.m_type = SET_ALARM;
-    m_sig.PROC_NR = proc_nr;
-    m_sig.DELTA_TICKS = HZ * sec;
+    proc_nr(m_sig) = proc_nr;
+    delta_ticks(m_sig) = HZ * sec;
     if (sec != 0)
         mproc[proc_nr].mp_flags |= ALARM_ON; /* turn ALARM_ON bit on */
     else

--- a/mm/utility.cpp
+++ b/mm/utility.cpp
@@ -109,15 +109,15 @@ PUBLIC int mem_copy(int src_proc, int src_seg, long src_vir, int dst_proc, int d
 
     if (bytes == 0L)
         return (OK);
-    copy_mess.SRC_SPACE = static_cast<char>(src_seg);
-    copy_mess.SRC_PROC_NR = src_proc;
-    copy_mess.SRC_BUFFER = src_vir;
+    src_space(copy_mess) = static_cast<char>(src_seg);
+    src_proc_nr(copy_mess) = src_proc;
+    src_buffer(copy_mess) = src_vir;
 
-    copy_mess.DST_SPACE = static_cast<char>(dst_seg);
-    copy_mess.DST_PROC_NR = dst_proc;
-    copy_mess.DST_BUFFER = dst_vir;
+    dst_space(copy_mess) = static_cast<char>(dst_seg);
+    dst_proc_nr(copy_mess) = dst_proc;
+    dst_buffer(copy_mess) = dst_vir;
 
-    copy_mess.COPY_BYTES = bytes;
+    copy_bytes(copy_mess) = bytes;
     sys_copy(&copy_mess);
     return (copy_mess.m_type);
 }


### PR DESCRIPTION
## Summary
- modernize `com.hpp` with constexpr constants and accessors
- replace macro field usage across kernel, fs, mm and lib
- document and format updated code

## Testing
- `cmake ..` *(fails: unknown type name 'name')*
- `cmake --build .` *(fails: error building lib/access.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_683a1202991483318c4c2ee82a7fbbf8