### PR TITLE
Add constexpr indices and RAII memory wrapper

### DIFF
--- a/include/lib.hpp
+++ b/include/lib.hpp
@@ -18,11 +18,11 @@
 extern message M;
 
 // Indices for the message passing service queues
-// Legacy macros still used throughout the code base
-#define MM 0 // memory manager index
-#define FS 1 // file system index
+// Converted to inline constexpr values for type safety.
+inline constexpr int MM = 0; // memory manager index
+inline constexpr int FS = 1; // file system index
 
-// C++17 constants for new code
+// Aliases kept for clarity in modern code
 inline constexpr int kMM = MM;
 inline constexpr int kFS = FS;
 extern int callm1(int proc, int syscallnr, int int1, int int2, int int3, char *ptr1, char *ptr2,
@@ -30,9 +30,64 @@ extern int callm1(int proc, int syscallnr, int int1, int int2, int int3, char *p
 extern int callm3(int proc, int syscallnr, int int1, char *name);
 extern int callx(int proc, int syscallnr);
 extern int len(char *s);
+extern int send(int dst, message *m_ptr);
+extern int receive(int src, message *m_ptr);
+extern int sendrec(int srcdest, message *m_ptr);
 extern int errno;
 extern int begsig(void); /* interrupts all vector here */
 
 /* Memory allocation wrappers */
 void *safe_malloc(size_t size);
 void safe_free(void *ptr);
+
+// RAII helper managing memory obtained through safe_malloc.
+// Automatically frees the memory when going out of scope.
+template <typename Type> class SafeBuffer {
+  public:
+    // Allocate space for 'count' objects of the given type using safe_malloc.
+    explicit SafeBuffer(std::size_t count = 1)
+        : size_(count), ptr_(static_cast<Type *>(safe_malloc(sizeof(Type) * count))) {}
+
+    // Free the owned memory.
+    ~SafeBuffer() { safe_free(ptr_); }
+
+    // Non-copyable to avoid double free.
+    SafeBuffer(const SafeBuffer &) = delete;
+    SafeBuffer &operator=(const SafeBuffer &) = delete;
+
+    // Move support for flexibility.
+    SafeBuffer(SafeBuffer &&other) noexcept : size_(other.size_), ptr_(other.ptr_) {
+        other.ptr_ = nullptr;
+        other.size_ = 0;
+    }
+    SafeBuffer &operator=(SafeBuffer &&other) noexcept {
+        if (this != &other) {
+            safe_free(ptr_);
+            ptr_ = other.ptr_;
+            size_ = other.size_;
+            other.ptr_ = nullptr;
+            other.size_ = 0;
+        }
+        return *this;
+    }
+
+    // Access the underlying pointer.
+    [[nodiscard]] Type *get() noexcept { return ptr_; }
+    [[nodiscard]] const Type *get() const noexcept { return ptr_; }
+
+    // Array-style element access.
+    Type &operator[](std::size_t idx) noexcept { return ptr_[idx]; }
+    const Type &operator[](std::size_t idx) const noexcept { return ptr_[idx]; }
+
+    // Release ownership without freeing.
+    [[nodiscard]] Type *release() noexcept {
+        Type *tmp = ptr_;
+        ptr_ = nullptr;
+        size_ = 0;
+        return tmp;
+    }
+
+  private:
+    std::size_t size_{}; // number of elements
+    Type *ptr_{nullptr}; // managed pointer
+};

--- a/lib/access.cpp
+++ b/lib/access.cpp
@@ -1,8 +1,7 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int access(name, mode)
-char *name;
-int mode;
-{
+// Wrapper around the ACCESS system call using the new interface.
+PUBLIC int access(char *name, int mode) {
+    // Delegate to the file system server via callm3.
     return callm3(FS, ACCESS, mode, name);
 }

--- a/lib/alarm.cpp
+++ b/lib/alarm.cpp
@@ -1,7 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int alarm(sec)
-unsigned sec;
-{
-    return callm1(MM, ALARM, (int)sec, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+// Request an alarm after the specified number of seconds.
+PUBLIC int alarm(unsigned sec) {
+    return callm1(MM, ALARM, static_cast<int>(sec), 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/bcopy.cpp
+++ b/lib/bcopy.cpp
@@ -1,7 +1,6 @@
-/* Copy a block of memory */
-void bcopy(char *old, char *new, int n)
-{
-/* Copy a block of data. */
-
-  while (n--) *new++ = *old++;
+/* Copy a block of memory from src to dest. */
+void bcopy(char *src, char *dest, int n) {
+    // Copy a block of data byte by byte.
+    while (n--)
+        *dest++ = *src++;
 }

--- a/lib/brk.cpp
+++ b/lib/brk.cpp
@@ -2,9 +2,8 @@
 
 extern char *brksize;
 
-PUBLIC char *brk(addr)
-char *addr;
-{
+// Set the program break to the address specified by 'addr'.
+PUBLIC char *brk(char *addr) {
     int k;
 
     k = callm1(MM, BRK, 0, 0, 0, addr, NIL_PTR, NIL_PTR);
@@ -16,14 +15,13 @@ char *addr;
     }
 }
 
-PUBLIC char *sbrk(incr)
-char *incr;
-{
+// Increment the program break by 'incr' bytes.
+PUBLIC char *sbrk(int incr) {
     char *newsize, *oldsize;
     extern int endv, dorgv;
 
     oldsize = brksize;
-    newsize = brksize + (int)incr;
+    newsize = brksize + incr;
     if (brk(newsize) == 0)
         return (oldsize);
     else

--- a/lib/brk2.cpp
+++ b/lib/brk2.cpp
@@ -1,6 +1,9 @@
 #include "../include/lib.hpp" // C++17 header
 
-/* Request memory segment move */
+// Forward declaration from getutil.cpp
+extern phys_clicks get_size(void);
+
+/* Request memory segment move to the end of BSS. */
 PUBLIC void brk2(void) {
     char *p1, *p2;
 

--- a/lib/call.cpp
+++ b/lib/call.cpp
@@ -2,16 +2,9 @@
 
 PUBLIC int errno; /* place where error numbers go */
 
-PUBLIC int callm1(proc, syscallnr, int1, int2, int3, ptr1, ptr2, ptr3)
-int proc;      /* FS or MM */
-int syscallnr; /* which system call */
-int int1;      /* first integer parameter */
-int int2;      /* second integer parameter */
-int int3;      /* third integer parameter */
-char *ptr1;    /* pointer parameter */
-char *ptr2;    /* pointer parameter */
-char *ptr3;    /* pointer parameter */
-{
+// Send a message using the m1 layout.
+PUBLIC int callm1(int proc, int syscallnr, int int1, int int2, int int3, char *ptr1, char *ptr2,
+                  char *ptr3) {
     /* Send a message and get the response.  The 'M.m_type' field of the
      * reply contains a value (>= 0) or an error code (<0). Use message format m1.
      */
@@ -24,12 +17,8 @@ char *ptr3;    /* pointer parameter */
     return callx(proc, syscallnr);
 }
 
-PUBLIC int callm3(proc, syscallnr, int1, name)
-int proc;      /* FS or MM */
-int syscallnr; /* which system call */
-int int1;      /* integer parameter */
-char *name;    /* string */
-{
+// Send a message containing one integer and a string.
+PUBLIC int callm3(int proc, int syscallnr, int int1, char *name) {
     /* This form of system call is used for those calls that contain at most
      * one integer parameter along with a string.  If the string fits in the
      * message, it is copied there.  If not, a pointer to it is passed.
@@ -47,10 +36,8 @@ char *name;    /* string */
     return callx(proc, syscallnr);
 }
 
-PUBLIC int callx(proc, syscallnr)
-int proc;      /* FS or MM */
-int syscallnr; /* which system call */
-{
+// Low-level send/receive wrapper.
+PUBLIC int callx(int proc, int syscallnr) {
     /* Send a message and get the response.  The 'M.m_type' field of the
      * reply contains a value (>= 0) or an error code (<0).
      */
@@ -67,9 +54,8 @@ int syscallnr; /* which system call */
     return (M.m_type);
 }
 
-PUBLIC int len(s)
-register char *s; /* character string whose length is needed */
-{
+// Return the length of a null-terminated string including the final null.
+PUBLIC int len(char *s) {
     /* Return the length of a character string, including the 0 at the end. */
     register int k;
 

--- a/lib/chdir.cpp
+++ b/lib/chdir.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chdir(name)
-char *name;
-{
-    return callm3(FS, CHDIR, 0, name);
-}
+// Change the current working directory to 'name'.
+PUBLIC int chdir(char *name) { return callm3(FS, CHDIR, 0, name); }

--- a/lib/chmod.cpp
+++ b/lib/chmod.cpp
@@ -1,8 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chmod(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, CHMOD, mode, name);
-}
+// Change the permissions of the file named 'name'.
+PUBLIC int chmod(char *name, int mode) { return callm3(FS, CHMOD, mode, name); }

--- a/lib/chown.cpp
+++ b/lib/chown.cpp
@@ -1,8 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chown(name, owner, grp)
-char *name;
-int owner, grp;
-{
+// Change ownership of 'name' to the given owner and group ids.
+PUBLIC int chown(char *name, int owner, int grp) {
     return callm1(FS, CHOWN, len(name), owner, grp, name, NIL_PTR, NIL_PTR);
 }

--- a/lib/chroot.cpp
+++ b/lib/chroot.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chroot(name)
-char *name;
-{
-    return callm3(FS, CHROOT, 0, name);
-}
+// Change the root directory for the current process.
+PUBLIC int chroot(char *name) { return callm3(FS, CHROOT, 0, name); }

--- a/lib/cleanup.cpp
+++ b/lib/cleanup.cpp
@@ -1,11 +1,11 @@
-#include "../include/stdio.h"
+#include "../include/stdio.hpp"
+
+extern "C" int fflush(FILE *);
 
 /* Flush all open stdio files */
-void _cleanup(void)
-{
-	register int i;
-
-	for ( i = 0 ; i < NFILES ; i++ )
-		if ( _io_table[i] != NULL )
-			fflush(_io_table[i]);
+// Flush all open stdio files at program exit.
+void _cleanup(void) {
+    for (int i = 0; i < NFILES; i++)
+        if (_io_table[i] != nullptr)
+            fflush(_io_table[i]);
 }

--- a/lib/close.cpp
+++ b/lib/close.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int close(fd)
-int fd;
-{
-    return callm1(FS, CLOSE, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Close the file descriptor 'fd'.
+PUBLIC int close(int fd) { return callm1(FS, CLOSE, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/creat.cpp
+++ b/lib/creat.cpp
@@ -1,8 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int creat(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, CREAT, mode, name);
-}
+// Create a new file with the specified mode.
+PUBLIC int creat(char *name, int mode) { return callm3(FS, CREAT, mode, name); }

--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -1,40 +1,43 @@
-char *crypt(pw, salt)
-char *pw, *salt;
-{
-	static char buf[14];
-        char bits[67];
-	register int i;
-	register int j, rot;
+#include <cstring>
 
-	for (i=0; i < 67; i++)
-		bits[i] = 0;
-	if (salt[1] == 0)
-		salt[1] = salt[0];
-	rot = (salt[1] * 4 - salt[0]) % 128;
-	for (i=0; *pw && i < 8; i++) {
-		for (j=0; j < 7; j++)
-			bits[i+j*8] = (*pw & (1 << j) ? 1 : 0);
-		bits[i+56] = (salt[i / 4] & (1 << (i % 4)) ? 1 : 0);
-		pw++;
-	}
-	bits[64] = (salt[0] & 1 ? 1 : 0);
-	bits[65] = (salt[1] & 1 ? 1 : 0);
-	bits[66] = (rot & 1 ? 1 : 0);
-	while (rot--) {
-		for (i=65; i >= 0; i--)
-			bits[i+1] = bits[i];
-		bits[0] = bits[66];
-	}
-	for (i=0; i < 12; i++) {
-		buf[i+2] = 0;
-		for (j=0; j < 6; j++)
-			buf[i+2] |= (bits[i*6+j] ? (1 << j) : 0);
-		buf[i+2] += 48;
-		if (buf[i+2] > '9') buf[i+2] += 7;
-		if (buf[i+2] > 'Z') buf[i+2] += 6;
-	}
-	buf[0] = salt[0];
-	buf[1] = salt[1];
-	buf[13] = '\0';
-	return(buf);
+// Very small DES-like password hashing used by early MINIX.
+char *crypt(char *pw, char *salt) {
+    static char buf[14];
+    char bits[67];
+    int i;
+    int j, rot;
+
+    for (i = 0; i < 67; i++)
+        bits[i] = 0;
+    if (salt[1] == 0)
+        salt[1] = salt[0];
+    rot = (salt[1] * 4 - salt[0]) % 128;
+    for (i = 0; *pw && i < 8; i++) {
+        for (j = 0; j < 7; j++)
+            bits[i + j * 8] = (*pw & (1 << j) ? 1 : 0);
+        bits[i + 56] = (salt[i / 4] & (1 << (i % 4)) ? 1 : 0);
+        pw++;
+    }
+    bits[64] = (salt[0] & 1 ? 1 : 0);
+    bits[65] = (salt[1] & 1 ? 1 : 0);
+    bits[66] = (rot & 1 ? 1 : 0);
+    while (rot--) {
+        for (i = 65; i >= 0; i--)
+            bits[i + 1] = bits[i];
+        bits[0] = bits[66];
+    }
+    for (i = 0; i < 12; i++) {
+        buf[i + 2] = 0;
+        for (j = 0; j < 6; j++)
+            buf[i + 2] |= (bits[i * 6 + j] ? (1 << j) : 0);
+        buf[i + 2] += 48;
+        if (buf[i + 2] > '9')
+            buf[i + 2] += 7;
+        if (buf[i + 2] > 'Z')
+            buf[i + 2] += 6;
+    }
+    buf[0] = salt[0];
+    buf[1] = salt[1];
+    buf[13] = '\0';
+    return (buf);
 }

--- a/lib/dup.cpp
+++ b/lib/dup.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int dup(fd)
-int fd;
-{
-    return callm1(FS, DUP, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Duplicate the given file descriptor.
+PUBLIC int dup(int fd) { return callm1(FS, DUP, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/dup2.cpp
+++ b/lib/dup2.cpp
@@ -1,7 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int dup2(fd, fd2)
-int fd, fd2;
-{
+// Duplicate 'fd' to the descriptor 'fd2'.
+PUBLIC int dup2(int fd, int fd2) {
     return callm1(FS, DUP, fd + 0100, fd2, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/syslib.cpp
+++ b/lib/syslib.cpp
@@ -3,14 +3,12 @@
 #include "../h/const.h"
 #include "../h/error.h"
 #include "../h/type.h"
+#include "../include/lib.hpp" // for message structure and constants
 #include <signal.h>
 
 #ifndef sighandler_t
 typedef void (*sighandler_t)(int);
 #endif
-
-#define FS FS_PROC_NR
-#define MM MMPROCNR
 
 extern int errno;
 extern message M;


### PR DESCRIPTION
## Summary
- modernize service queue indices by converting macros to constexpr values
- implement `SafeBuffer` RAII wrapper for `safe_malloc` allocations
- apply RAII in `alloc_extent_table`
- include new header where required

## Testing
- `make` *(fails: exec.cpp compile errors)*
- `ctest --test-dir build` *(fails: executables not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683a123902148331adc0175fd1cca6fe