### PR TITLE
Refactor libc functions to modern style

### DIFF
--- a/commands/ar.cpp
+++ b/commands/ar.cpp
@@ -411,14 +411,17 @@ static void print_mode(int mode) {
 
     mode_buf[9] = ' ';
     for (i = 0; i < 3; i++) {
-        mode_buf[i * 3] = (tmp & S_IREAD) ? 'r' : '-';
-        mode_buf[i * 3 + 1] = (tmp & S_IWRITE) ? 'w' : '-';
-        mode_buf[i * 3 + 2] = (tmp & S_IEXEC) ? 'x' : '-';
+        mode_buf[i * 3] =
+            (tmp & static_cast<unsigned short>(FileMode::S_IREAD)) ? 'r' : '-';
+        mode_buf[i * 3 + 1] =
+            (tmp & static_cast<unsigned short>(FileMode::S_IWRITE)) ? 'w' : '-';
+        mode_buf[i * 3 + 2] =
+            (tmp & static_cast<unsigned short>(FileMode::S_IEXEC)) ? 'x' : '-';
         tmp <<= 3;
     }
-    if (mode & S_ISUID)
+    if (mode & static_cast<unsigned short>(FileMode::S_ISUID))
         mode_buf[2] = 's';
-    if (mode & S_ISGID)
+    if (mode & static_cast<unsigned short>(FileMode::S_ISGID))
         mode_buf[5] = 's';
     print(mode_buf);
 }

--- a/commands/df.cpp
+++ b/commands/df.cpp
@@ -48,7 +48,8 @@ static void df(char *name) {
         stderr2(name, ": Cannot stat\n");
         return;
     }
-    if ((statbuf.st_mode & S_IFMT) != S_IFBLK) {
+    if ((statbuf.st_mode & FileMode::S_IFMT) !=
+        static_cast<unsigned short>(FileMode::S_IFBLK)) {
         stderr2(name, ": not a block special file\n");
         return;
     }

--- a/commands/ln.cpp
+++ b/commands/ln.cpp
@@ -21,7 +21,9 @@ int main(int argc, char **argv) {
         std_err("\n");
         exit(1);
     }
-    if (stat(argv[1], &stb) >= 0 && (stb.st_mode & S_IFMT) == S_IFDIR)
+    if (stat(argv[1], &stb) >= 0 &&
+        (stb.st_mode & FileMode::S_IFMT) ==
+            static_cast<unsigned short>(FileMode::S_IFDIR))
         usage();
     file1 = argv[1];
 
@@ -32,7 +34,9 @@ int main(int argc, char **argv) {
         file2 = argv[2];
 
     /* Check to see if target is a directory. */
-    if (stat(file2, &stb) >= 0 && (stb.st_mode & S_IFMT) == S_IFDIR) {
+    if (stat(file2, &stb) >= 0 &&
+        (stb.st_mode & FileMode::S_IFMT) ==
+            static_cast<unsigned short>(FileMode::S_IFDIR)) {
         strcpy(name, file2);
         strcat(name, "/");
         strcat(name, last_comp(file1));

--- a/commands/mkfs.cpp
+++ b/commands/mkfs.cpp
@@ -108,7 +108,8 @@ char *argv[];
     if (argc != 3 && argc != 4)
         badusage = 1;
     if (stat(argv[argc - 1], &statbuf) == 0) {
-        if ((statbuf.st_mode & S_IFMT) != S_IFREG)
+        if ((statbuf.st_mode & FileMode::S_IFMT) !=
+            static_cast<unsigned short>(FileMode::S_IFREG))
             badusage = 1;
     }
     if (badusage) {

--- a/commands/mv.cpp
+++ b/commands/mv.cpp
@@ -27,8 +27,11 @@ int main(int argc, char **argv) {
             std_err(" doesn't exist\n");
             exit(1);
         }
-        if ((st.st_mode & S_IFMT) == S_IFDIR) {
-            if (!stat(argv[2], &st) && (st.st_mode & S_IFMT) == S_IFDIR) {
+        if ((st.st_mode & FileMode::S_IFMT) ==
+            static_cast<unsigned short>(FileMode::S_IFDIR)) {
+            if (!stat(argv[2], &st) &&
+                (st.st_mode & FileMode::S_IFMT) ==
+                    static_cast<unsigned short>(FileMode::S_IFDIR)) {
                 std_err("mv: target ");
                 std_err(argv[2]);
                 std_err(" exists\n");
@@ -49,7 +52,8 @@ int main(int argc, char **argv) {
             std_err(" doesn't exist\n");
             exit(1);
         }
-        if ((st.st_mode & S_IFMT) != S_IFDIR) {
+        if ((st.st_mode & FileMode::S_IFMT) !=
+            static_cast<unsigned short>(FileMode::S_IFDIR)) {
             std_err("mv: target ");
             std_err(destdir);
             std_err(" not a directory\n");
@@ -68,7 +72,8 @@ static void move(char *old, char *new) {
     int retval;
 
     if (!stat(new, &st))
-        if ((st.st_mode & S_IFMT) != S_IFDIR)
+        if ((st.st_mode & FileMode::S_IFMT) !=
+            static_cast<unsigned short>(FileMode::S_IFDIR))
             unlink(new);
         else {
             char name[64], *p, *rindex();
@@ -86,7 +91,8 @@ static void move(char *old, char *new) {
         }
     stat(old, &st);
     if (link(old, new))
-        if ((st.st_mode & S_IFMT) != S_IFDIR) {
+        if ((st.st_mode & FileMode::S_IFMT) !=
+            static_cast<unsigned short>(FileMode::S_IFDIR)) {
             switch (fork()) {
             case 0:
                 execl("/bin/cp", "cp", old, new, 0);

--- a/commands/rm.cpp
+++ b/commands/rm.cpp
@@ -78,7 +78,8 @@ static void remove(char *name) {
         if (!confirm())
             return;
     }
-    if ((s.st_mode & S_IFMT) == S_IFDIR) {
+    if ((s.st_mode & FileMode::S_IFMT) ==
+        static_cast<unsigned short>(FileMode::S_IFDIR)) {
         if (rflag) {
             if ((fd = open(name, 0)) < 0) {
                 if (!fflag)
@@ -105,7 +106,7 @@ static void remove(char *name) {
     } else {
         if (access(name, 2) && !fflag) {
             stderr3("rm: remove ", name, " with mode ");
-            octal(s.st_mode & 0777);
+            octal(static_cast<unsigned short>(s.st_mode) & 0777);
             std_err("? ");
             if (!confirm())
                 return;

--- a/commands/rmdir.cpp
+++ b/commands/rmdir.cpp
@@ -43,7 +43,8 @@ static void remove(char *dirname) {
         error++;
         return;
     }
-    if ((s.st_mode & S_IFMT) != S_IFDIR) {
+    if ((s.st_mode & FileMode::S_IFMT) !=
+        static_cast<unsigned short>(FileMode::S_IFDIR)) {
         stderr2(dirname, " not a directory\n");
         error++;
         return;

--- a/commands/tar.cpp
+++ b/commands/tar.cpp
@@ -322,9 +322,9 @@ add_file(file) register char *file;
 
     make_header(path_name(file), &st);
     mwrite(tar_fd, &header, sizeof(header));
-    if (st.st_mode & S_IFREG)
+    if (static_cast<unsigned short>(st.st_mode & FileMode::S_IFREG))
         copy(path_name(file), fd, tar_fd, st.st_size);
-    else if (st.st_mode & S_IFDIR) {
+    else if (static_cast<unsigned short>(st.st_mode & FileMode::S_IFDIR)) {
         if (chdir(file) < 0)
             string_print(NIL_PTR, "Cannot chdir to %s\n", file);
         else {
@@ -353,12 +353,13 @@ register struct stat *st;
     while (*ptr++ = *file++)
         ;
 
-    if (st->st_mode & S_IFDIR) {
+    if (static_cast<unsigned short>(st->st_mode & FileMode::S_IFDIR)) {
         *(ptr - 1) = '/';
         st->st_size = 0L;
     }
 
-    string_print(header.member.m_mode, "%I ", st->st_mode & 07777);
+    string_print(header.member.m_mode, "%I ",
+                 static_cast<unsigned short>(st->st_mode) & 07777);
     string_print(header.member.m_uid, "%I ", st->st_uid);
     string_print(header.member.m_gid, "%I ", st->st_gid);
     string_print(header.member.m_size, "%L ", st->st_size);

--- a/commands/touch.cpp
+++ b/commands/touch.cpp
@@ -43,8 +43,8 @@ static int doit(const char *name) {
 
     if (!access(name, 0)) { /* change date if possible */
         stat(name, &buf);
-        tmp = (buf.st_mode & S_IFREG);
-        if (tmp != S_IFREG)
+        tmp = (buf.st_mode & FileMode::S_IFREG);
+        if (tmp != static_cast<unsigned short>(FileMode::S_IFREG))
             return (1);
 
         tim = time(0L);

--- a/fs/stadir.cpp
+++ b/fs/stadir.cpp
@@ -159,7 +159,7 @@ char *user_addr;            /* user space address where stat buf goes */
     stp = &statbuf; /* set up pointer to the buffer */
     stp->st_dev = (int)rip->i_dev;
     stp->st_ino = rip->i_num;
-    stp->st_mode = rip->i_mode;
+    stp->st_mode = static_cast<FileMode>(rip->i_mode);
     stp->st_nlink = rip->i_nlinks & BYTE;
     stp->st_uid = rip->i_uid;
     stp->st_gid = rip->i_gid & BYTE;

--- a/h/stat.hpp
+++ b/h/stat.hpp
@@ -1,32 +1,45 @@
-/*<<< WORK-IN-PROGRESS MODERNIZATION HEADER
-  This repository is a work in progress to reproduce the
-  original MINIX simplicity on modern 32-bit and 64-bit
-  ARM and x86/x86_64 hardware using C++17.
->>>*/
+#pragma once
+// Modernized for C++17
 
-struct stat {
-    short int st_dev;
-    unsigned short st_ino;
-    unsigned short st_mode;
-    short int st_nlink;
-    short int st_uid;
-    short int st_gid;
-    short int st_rdev;
-    long st_size;
-    long st_atime;
-    long st_mtime;
-    long st_ctime;
+// Scoped bit flags describing the file type and permissions.
+enum class FileMode : unsigned short {
+    S_IFMT = 0170000,  // mask for file type bits
+    S_IFDIR = 0040000, // directory
+    S_IFCHR = 0020000, // character special
+    S_IFBLK = 0060000, // block special
+    S_IFREG = 0100000, // regular file
+    S_ISUID = 04000,   // set user id on execution
+    S_ISGID = 02000,   // set group id on execution
+    S_ISVTX = 01000,   // save swapped text even after use
+    S_IREAD = 00400,   // read permission, owner
+    S_IWRITE = 00200,  // write permission, owner
+    S_IEXEC = 00100    // execute/search permission, owner
 };
 
-/* Some common definitions. */
-#define S_IFMT 0170000  /* type of file */
-#define S_IFDIR 0040000 /* directory */
-#define S_IFCHR 0020000 /* character special */
-#define S_IFBLK 0060000 /* block special */
-#define S_IFREG 0100000 /* regular */
-#define S_ISUID 04000   /* set user id on execution */
-#define S_ISGID 02000   /* set group id on execution */
-#define S_ISVTX 01000   /* save swapped text even after use */
-#define S_IREAD 00400   /* read permission, owner */
-#define S_IWRITE 00200  /* write permission, owner */
-#define S_IEXEC 00100   /* execute/search permission, owner */
+// Standard file status information returned by stat().
+struct stat {
+    short int st_dev;  // device number
+    unsigned short st_ino; // inode number
+    FileMode st_mode;  // file type and permissions
+    short int st_nlink; // link count
+    short int st_uid;   // owner user id
+    short int st_gid;   // owner group id
+    short int st_rdev;  // special device number
+    long st_size;       // file size in bytes
+    long st_atime;      // last access time
+    long st_mtime;      // last modification time
+    long st_ctime;      // creation time
+};
+
+// Enable bitwise and masking semantics for FileMode values.
+constexpr unsigned short operator&(FileMode lhs, FileMode rhs) {
+    return static_cast<unsigned short>(lhs) & static_cast<unsigned short>(rhs);
+}
+
+constexpr unsigned short operator&(FileMode lhs, unsigned short rhs) {
+    return static_cast<unsigned short>(lhs) & rhs;
+}
+
+constexpr unsigned short operator&(unsigned short lhs, FileMode rhs) {
+    return lhs & static_cast<unsigned short>(rhs);
+}

--- a/include/lib.hpp
+++ b/include/lib.hpp
@@ -30,6 +30,9 @@ extern int callm1(int proc, int syscallnr, int int1, int int2, int int3, char *p
 extern int callm3(int proc, int syscallnr, int int1, char *name);
 extern int callx(int proc, int syscallnr);
 extern int len(char *s);
+extern int send(int dst, message *m_ptr);
+extern int receive(int src, message *m_ptr);
+extern int sendrec(int srcdest, message *m_ptr);
 extern int errno;
 extern int begsig(void); /* interrupts all vector here */
 

--- a/include/stat.hpp
+++ b/include/stat.hpp
@@ -1,32 +1,45 @@
-/*<<< WORK-IN-PROGRESS MODERNIZATION HEADER
-  This repository is a work in progress to reproduce the
-  original MINIX simplicity on modern 32-bit and 64-bit
-  ARM and x86/x86_64 hardware using C++17.
->>>*/
+#pragma once
+// Modernized for C++17
 
-struct stat {
-    short int st_dev;
-    unsigned short st_ino;
-    unsigned short st_mode;
-    short int st_nlink;
-    short int st_uid;
-    short int st_gid;
-    short int st_rdev;
-    long st_size;
-    long st_atime;
-    long st_mtime;
-    long st_ctime;
+// Scoped bit flags describing the file type and permissions.
+enum class FileMode : unsigned short {
+    S_IFMT = 0170000,  // mask for file type bits
+    S_IFDIR = 0040000, // directory
+    S_IFCHR = 0020000, // character special
+    S_IFBLK = 0060000, // block special
+    S_IFREG = 0100000, // regular file
+    S_ISUID = 04000,   // set user id on execution
+    S_ISGID = 02000,   // set group id on execution
+    S_ISVTX = 01000,   // save swapped text even after use
+    S_IREAD = 00400,   // read permission, owner
+    S_IWRITE = 00200,  // write permission, owner
+    S_IEXEC = 00100    // execute/search permission, owner
 };
 
-/* Some common definitions. */
-#define S_IFMT 0170000  /* type of file */
-#define S_IFDIR 0040000 /* directory */
-#define S_IFCHR 0020000 /* character special */
-#define S_IFBLK 0060000 /* block special */
-#define S_IFREG 0100000 /* regular */
-#define S_ISUID 04000   /* set user id on execution */
-#define S_ISGID 02000   /* set group id on execution */
-#define S_ISVTX 01000   /* save swapped text even after use */
-#define S_IREAD 00400   /* read permission, owner */
-#define S_IWRITE 00200  /* write permission, owner */
-#define S_IEXEC 00100   /* execute/search permission, owner */
+// Standard file status information returned by stat().
+struct stat {
+    short int st_dev;  // device number
+    unsigned short st_ino; // inode number
+    FileMode st_mode;  // file type and permissions
+    short int st_nlink; // link count
+    short int st_uid;   // owner user id
+    short int st_gid;   // owner group id
+    short int st_rdev;  // special device number
+    long st_size;       // file size in bytes
+    long st_atime;      // last access time
+    long st_mtime;      // last modification time
+    long st_ctime;      // creation time
+};
+
+// Enable bitwise and masking semantics for FileMode values.
+constexpr unsigned short operator&(FileMode lhs, FileMode rhs) {
+    return static_cast<unsigned short>(lhs) & static_cast<unsigned short>(rhs);
+}
+
+constexpr unsigned short operator&(FileMode lhs, unsigned short rhs) {
+    return static_cast<unsigned short>(lhs) & rhs;
+}
+
+constexpr unsigned short operator&(unsigned short lhs, FileMode rhs) {
+    return lhs & static_cast<unsigned short>(rhs);
+}

--- a/include/stdio.hpp
+++ b/include/stdio.hpp
@@ -28,10 +28,12 @@ extern struct _io_buf {
     char *_buf;
     char *_ptr;
 } *_io_table[NFILES];
-
 #endif /* FILE */
 
 #define FILE struct _io_buf
+
+/* Standard I/O prototypes */
+int fflush(FILE *iop);
 
 #define stdin (_io_table[0])
 #define stdout (_io_table[1])

--- a/lib/access.cpp
+++ b/lib/access.cpp
@@ -1,8 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int access(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, ACCESS, mode, name);
+// Access a file to check permissions using C++ style parameters.
+PUBLIC int access(const char *name, int mode) {
+    return callm3(FS, ACCESS, mode, const_cast<char *>(name));
 }

--- a/lib/alarm.cpp
+++ b/lib/alarm.cpp
@@ -1,7 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int alarm(sec)
-unsigned sec;
-{
-    return callm1(MM, ALARM, (int)sec, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+// Request a timer alarm in 'sec' seconds.
+PUBLIC int alarm(unsigned sec) {
+    return callm1(MM, ALARM, static_cast<int>(sec), 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/bcopy.cpp
+++ b/lib/bcopy.cpp
@@ -1,7 +1,7 @@
 /* Copy a block of memory */
-void bcopy(char *old, char *new, int n)
-{
-/* Copy a block of data. */
+void bcopy(char *old, char *dest, int n) {
+    /* Copy a block of data. */
 
-  while (n--) *new++ = *old++;
+    while (n--)
+        *dest++ = *old++;
 }

--- a/lib/brk.cpp
+++ b/lib/brk.cpp
@@ -2,30 +2,26 @@
 
 extern char *brksize;
 
-PUBLIC char *brk(addr)
-char *addr;
-{
+// Set the program break to the address 'addr'.
+PUBLIC char *brk(char *addr) {
     int k;
 
     k = callm1(MM, BRK, 0, 0, 0, addr, NIL_PTR, NIL_PTR);
     if (k == OK) {
         brksize = M.m2_p1;
-        return (NIL_PTR);
-    } else {
-        return ((char *)-1);
+        return NIL_PTR;
     }
+    return reinterpret_cast<char *>(-1);
 }
 
-PUBLIC char *sbrk(incr)
-char *incr;
-{
+// Adjust the program break by 'incr' bytes.
+PUBLIC char *sbrk(int incr) {
     char *newsize, *oldsize;
     extern int endv, dorgv;
 
     oldsize = brksize;
-    newsize = brksize + (int)incr;
+    newsize = brksize + incr;
     if (brk(newsize) == 0)
-        return (oldsize);
-    else
-        return ((char *)-1);
+        return oldsize;
+    return reinterpret_cast<char *>(-1);
 }

--- a/lib/brk2.cpp
+++ b/lib/brk2.cpp
@@ -1,9 +1,11 @@
 #include "../include/lib.hpp" // C++17 header
 
 /* Request memory segment move */
-PUBLIC void brk2(void) {
+extern "C" phys_clicks get_size(void);
+
+PUBLIC void brk2() {
     char *p1, *p2;
 
-    p1 = (char *)get_size();
+    p1 = reinterpret_cast<char *>(get_size());
     callm1(MM, BRK2, 0, 0, 0, p1, p2, NIL_PTR);
 }

--- a/lib/call.cpp
+++ b/lib/call.cpp
@@ -2,16 +2,9 @@
 
 PUBLIC int errno; /* place where error numbers go */
 
-PUBLIC int callm1(proc, syscallnr, int1, int2, int3, ptr1, ptr2, ptr3)
-int proc;      /* FS or MM */
-int syscallnr; /* which system call */
-int int1;      /* first integer parameter */
-int int2;      /* second integer parameter */
-int int3;      /* third integer parameter */
-char *ptr1;    /* pointer parameter */
-char *ptr2;    /* pointer parameter */
-char *ptr3;    /* pointer parameter */
-{
+// Send a message with three integer and three pointer parameters.
+PUBLIC int callm1(int proc, int syscallnr, int int1, int int2, int int3, char *ptr1, char *ptr2,
+                  char *ptr3) {
     /* Send a message and get the response.  The 'M.m_type' field of the
      * reply contains a value (>= 0) or an error code (<0). Use message format m1.
      */
@@ -24,12 +17,8 @@ char *ptr3;    /* pointer parameter */
     return callx(proc, syscallnr);
 }
 
-PUBLIC int callm3(proc, syscallnr, int1, name)
-int proc;      /* FS or MM */
-int syscallnr; /* which system call */
-int int1;      /* integer parameter */
-char *name;    /* string */
-{
+// Send a message with one integer and a string parameter.
+PUBLIC int callm3(int proc, int syscallnr, int int1, char *name) {
     /* This form of system call is used for those calls that contain at most
      * one integer parameter along with a string.  If the string fits in the
      * message, it is copied there.  If not, a pointer to it is passed.
@@ -47,10 +36,8 @@ char *name;    /* string */
     return callx(proc, syscallnr);
 }
 
-PUBLIC int callx(proc, syscallnr)
-int proc;      /* FS or MM */
-int syscallnr; /* which system call */
-{
+// Low-level send/receive routine.
+PUBLIC int callx(int proc, int syscallnr) {
     /* Send a message and get the response.  The 'M.m_type' field of the
      * reply contains a value (>= 0) or an error code (<0).
      */
@@ -67,9 +54,8 @@ int syscallnr; /* which system call */
     return (M.m_type);
 }
 
-PUBLIC int len(s)
-register char *s; /* character string whose length is needed */
-{
+// Compute the length of a string including the trailing null.
+PUBLIC int len(char *s) {
     /* Return the length of a character string, including the 0 at the end. */
     register int k;
 

--- a/lib/chdir.cpp
+++ b/lib/chdir.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chdir(name)
-char *name;
-{
-    return callm3(FS, CHDIR, 0, name);
-}
+// Change the current working directory.
+PUBLIC int chdir(const char *name) { return callm3(FS, CHDIR, 0, const_cast<char *>(name)); }

--- a/lib/chmod.cpp
+++ b/lib/chmod.cpp
@@ -1,8 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chmod(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, CHMOD, mode, name);
+// Change the permissions of 'name'.
+PUBLIC int chmod(const char *name, int mode) {
+    return callm3(FS, CHMOD, mode, const_cast<char *>(name));
 }

--- a/lib/chown.cpp
+++ b/lib/chown.cpp
@@ -1,8 +1,7 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chown(name, owner, grp)
-char *name;
-int owner, grp;
-{
-    return callm1(FS, CHOWN, len(name), owner, grp, name, NIL_PTR, NIL_PTR);
+// Change owner and group of a file.
+PUBLIC int chown(const char *name, int owner, int grp) {
+    return callm1(FS, CHOWN, len(const_cast<char *>(name)), owner, grp, const_cast<char *>(name),
+                  NIL_PTR, NIL_PTR);
 }

--- a/lib/chroot.cpp
+++ b/lib/chroot.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int chroot(name)
-char *name;
-{
-    return callm3(FS, CHROOT, 0, name);
-}
+// Change the root directory for the calling process.
+PUBLIC int chroot(const char *name) { return callm3(FS, CHROOT, 0, const_cast<char *>(name)); }

--- a/lib/cleanup.cpp
+++ b/lib/cleanup.cpp
@@ -1,11 +1,10 @@
-#include "../include/stdio.h"
+#include "../include/stdio.hpp"
 
 /* Flush all open stdio files */
-void _cleanup(void)
-{
-	register int i;
+void _cleanup(void) {
+    register int i;
 
-	for ( i = 0 ; i < NFILES ; i++ )
-		if ( _io_table[i] != NULL )
-			fflush(_io_table[i]);
+    for (i = 0; i < NFILES; i++)
+        if (_io_table[i] != NULL)
+            fflush(_io_table[i]);
 }

--- a/lib/close.cpp
+++ b/lib/close.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int close(fd)
-int fd;
-{
-    return callm1(FS, CLOSE, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Close an open file descriptor.
+PUBLIC int close(int fd) { return callm1(FS, CLOSE, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/creat.cpp
+++ b/lib/creat.cpp
@@ -1,8 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int creat(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, CREAT, mode, name);
+// Create a new file with permissions 'mode'.
+PUBLIC int creat(const char *name, int mode) {
+    return callm3(FS, CREAT, mode, const_cast<char *>(name));
 }

--- a/lib/dup.cpp
+++ b/lib/dup.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int dup(fd)
-int fd;
-{
-    return callm1(FS, DUP, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Duplicate an existing file descriptor.
+PUBLIC int dup(int fd) { return callm1(FS, DUP, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/dup2.cpp
+++ b/lib/dup2.cpp
@@ -1,7 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int dup2(fd, fd2)
-int fd, fd2;
-{
+// Duplicate 'fd' to the descriptor number 'fd2'.
+PUBLIC int dup2(int fd, int fd2) {
     return callm1(FS, DUP, fd + 0100, fd2, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/exec.cpp
+++ b/lib/exec.cpp
@@ -2,16 +2,11 @@
 
 char *nullptr[1]; /* the EXEC calls need a zero pointer */
 
-PUBLIC int execl(name, arg0)
-char *name;
-char *arg0;
-{
-    return execve(name, &arg0, nullptr);
-}
+// Execute a program with a list of arguments.
+PUBLIC int execl(const char *name, char *arg0) { return execve(name, &arg0, nullptr); }
 
-PUBLIC int execle(name, argv)
-char *name, *argv;
-{
+// Execute a program with given environment.
+PUBLIC int execle(const char *name, char *argv) {
     char **p;
     p = (char **)&argv;
     while (*p++) /* null statement */
@@ -19,17 +14,11 @@ char *name, *argv;
     return execve(name, &argv, *p);
 }
 
-PUBLIC int execv(name, argv)
-char *name, *argv[];
-{
-    return execve(name, argv, nullptr);
-}
+// Execute a program with argument array.
+PUBLIC int execv(const char *name, char *argv[]) { return execve(name, argv, nullptr); }
 
-PUBLIC int execve(name, argv, envp)
-char *name;   /* pointer to name of file to be executed */
-char *argv[]; /* pointer to argument array */
-char *envp[]; /* pointer to environment */
-{
+// Low level execve system call wrapper.
+PUBLIC int execve(const char *name, char *argv[], char *envp[]) {
     char stack[MAX_ISTACK_BYTES];
     char **argorg, **envorg, *hp, **ap, *p;
     int i, nargs, nenvps, stackbytes, ptrsize, offset;
@@ -83,11 +72,11 @@ char *envp[]; /* pointer to environment */
     return callm1(MM_PROC_NR, EXEC, len(name), stackbytes, 0, name, stack, NIL_PTR);
 }
 
-PUBLIC execn(name)
-char *name; /* pointer to file to be exec'd */
-{
-    /* Special version used when there are no args and no environment.  This call
-     * is principally used by INIT, to avoid having to allocate MAX_ISTACK_BYTES.
+// Exec a program without arguments or environment.
+PUBLIC int execn(const char *name) {
+    /* Special version used when there are no args and no environment.  This
+     * call is principally used by INIT, to avoid having to allocate
+     * MAX_ISTACK_BYTES.
      */
 
     char stack[4];

--- a/lib/exit.cpp
+++ b/lib/exit.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int exit(status)
-int status;
-{
-    return callm1(MM, EXIT, status, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Terminate the process with a status code.
+PUBLIC int exit(int status) { return callm1(MM, EXIT, status, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/fflush.cpp
+++ b/lib/fflush.cpp
@@ -1,26 +1,22 @@
-#include "../include/stdio.h"
+#include "../include/stdio.hpp"
 
+int fflush(FILE *iop) {
+    int count;
 
-fflush(iop)
-FILE *iop;
-{
-	int count;
+    if (testflag(iop, UNBUFF) || !testflag(iop, WRITEMODE))
+        return 0;
 
-	if ( testflag(iop,UNBUFF) || !testflag(iop,WRITEMODE) ) 
-		return(0);
+    if (iop->_count <= 0)
+        return 0;
 
-	if ( iop->_count <= 0 )
-		return(0);
+    count = write(iop->_fd, iop->_buf, iop->_count);
 
-	count = write(iop->_fd,iop->_buf,iop->_count);
+    if (count == iop->_count) {
+        iop->_count = 0;
+        iop->_ptr = iop->_buf;
+        return count;
+    }
 
-	if ( count == iop->_count) {
-		iop->_count = 0;
-		iop->_ptr   = iop->_buf;
-		return(count);
-	}
-
-	iop->_flags |= _ERR;
-	return(EOF); 
+    iop->_flags |= _ERR;
+    return EOF;
 }
-

--- a/lib/fstat.cpp
+++ b/lib/fstat.cpp
@@ -1,10 +1,8 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int fstat(fd, buffer)
-int fd;
-char *buffer;
-{
+// Obtain file status for an open descriptor.
+PUBLIC int fstat(int fd, char *buffer) {
     int n;
     n = callm1(FS, FSTAT, fd, 0, 0, buffer, NIL_PTR, NIL_PTR);
-    return (n);
+    return n;
 }

--- a/lib/getenv.cpp
+++ b/lib/getenv.cpp
@@ -1,18 +1,17 @@
-#define NULL  (char *) 0
-char *getenv(name)
-register char *name;
-{
-  extern char **environ;
-  register char **v = environ, *p, *q;
+#include <cstddef>
 
-  while ((p = *v) != NULL) {
-	q = name;
-	while (*p++ == *q)
-		if (*q++ == 0)
-			continue;
-	if (*(p - 1) != '=')
-		continue;
-	return(p);
-  }
-  return(0);
+// Retrieve the value of environment variable 'name'.
+char *getenv(const char *name) {
+    extern char **environ;
+    char **v = environ;
+    while (char *p = *v++) {
+        const char *q = name;
+        while (*p++ == *q)
+            if (*q++ == 0)
+                continue;
+        if (*(p - 1) != '=')
+            continue;
+        return p;
+    }
+    return nullptr;
 }

--- a/lib/ioctl.cpp
+++ b/lib/ioctl.cpp
@@ -2,15 +2,13 @@
 #include "../include/lib.hpp" // C++17 header
 #include "../include/sgtty.h"
 
-PUBLIC int ioctl(fd, request, u)
-int fd;
-int request;
-union {
-    struct sgttyb *argp;
-    struct tchars *argt;
-} u;
-
-{
+// Generic ioctl implementation.
+PUBLIC int ioctl(int fd, int request, void *arg) {
+    union {
+        struct sgttyb *argp;
+        struct tchars *argt;
+    } u;
+    u.argp = static_cast<struct sgttyb *>(arg);
     int n;
     long erase, kill, intr, quit, xon, xoff, eof, brk;
 

--- a/lib/isatty.cpp
+++ b/lib/isatty.cpp
@@ -1,4 +1,4 @@
-#include "../include/stat.h"
+#include "../include/stat.hpp"
 
 int isatty(fd)
 int fd;
@@ -6,7 +6,8 @@ int fd;
   struct stat s;
 
   fstat(fd, &s);
-  if ( (s.st_mode&S_IFMT) == S_IFCHR)
+  if ((s.st_mode & FileMode::S_IFMT) ==
+      static_cast<unsigned short>(FileMode::S_IFCHR))
 	return(1);
   else
 	return(0);

--- a/lib/kill.cpp
+++ b/lib/kill.cpp
@@ -1,8 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int kill(proc, sig)
-int proc; /* which process is to be sent the signal */
-int sig;  /* signal number */
-{
+// Send signal 'sig' to process 'proc'.
+PUBLIC int kill(int proc, int sig) {
     return callm1(MM, KILL, proc, sig, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/link.cpp
+++ b/lib/link.cpp
@@ -1,7 +1,7 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int link(name, name2)
-char *name, *name2;
-{
-    return callm1(FS, LINK, len(name), len(name2), 0, name, name2, NIL_PTR);
+// Create a hard link from 'name' to 'name2'.
+PUBLIC int link(const char *name, const char *name2) {
+    return callm1(FS, LINK, len(const_cast<char *>(name)), len(const_cast<char *>(name2)), 0,
+                  const_cast<char *>(name), const_cast<char *>(name2), NIL_PTR);
 }

--- a/lib/lseek.cpp
+++ b/lib/lseek.cpp
@@ -1,16 +1,13 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC long lseek(fd, offset, whence)
-int fd;
-long offset;
-int whence;
-{
+// Reposition read/write file offset.
+PUBLIC long lseek(int fd, long offset, int whence) {
     int k;
     M.m2_i1 = fd;
     M.m2_l1 = offset;
     M.m2_i2 = whence;
     k = callx(FS, LSEEK);
     if (k != OK)
-        return ((long)k); /* send itself failed */
-    return (M.m2_l1);
+        return static_cast<long>(k); /* send itself failed */
+    return M.m2_l1;
 }

--- a/lib/mknod.cpp
+++ b/lib/mknod.cpp
@@ -1,8 +1,7 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int mknod(name, mode, addr)
-char *name;
-int mode, addr;
-{
-    return callm1(FS, MKNOD, len(name), mode, addr, name, NIL_PTR, NIL_PTR);
+// Create a special file with mode and device number.
+PUBLIC int mknod(const char *name, int mode, int addr) {
+    return callm1(FS, MKNOD, len(const_cast<char *>(name)), mode, addr, const_cast<char *>(name),
+                  NIL_PTR, NIL_PTR);
 }

--- a/lib/mount.cpp
+++ b/lib/mount.cpp
@@ -1,8 +1,7 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int mount(special, name, rwflag)
-char *name, *special;
-int rwflag;
-{
-    return callm1(FS, MOUNT, len(special), len(name), rwflag, special, name, NIL_PTR);
+// Mount a file system.
+PUBLIC int mount(const char *special, const char *name, int rwflag) {
+    return callm1(FS, MOUNT, len(const_cast<char *>(special)), len(const_cast<char *>(name)),
+                  rwflag, const_cast<char *>(special), const_cast<char *>(name), NIL_PTR);
 }

--- a/lib/open.cpp
+++ b/lib/open.cpp
@@ -1,8 +1,6 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int open(name, mode)
-char *name;
-int mode;
-{
-    return callm3(FS, OPEN, mode, name);
+// Open a file with the given mode.
+PUBLIC int open(const char *name, int mode) {
+    return callm3(FS, OPEN, mode, const_cast<char *>(name));
 }

--- a/lib/pipe.cpp
+++ b/lib/pipe.cpp
@@ -1,14 +1,13 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int pipe(fild)
-int fild[2];
-{
+// Create a pipe and return two file descriptors in 'fild'.
+PUBLIC int pipe(int fild[2]) {
     int k;
     k = callm1(FS, PIPE, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     if (k >= 0) {
         fild[0] = M.m1_i1;
         fild[1] = M.m1_i2;
-        return (0);
-    } else
-        return (k);
+        return 0;
+    }
+    return k;
 }

--- a/lib/read.cpp
+++ b/lib/read.cpp
@@ -1,11 +1,8 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int read(fd, buffer, nbytes)
-int fd;
-char *buffer;
-int nbytes;
-{
+// Read from a file descriptor into 'buffer'.
+PUBLIC int read(int fd, char *buffer, int nbytes) {
     int n;
     n = callm1(FS, READ, fd, nbytes, 0, buffer, NIL_PTR, NIL_PTR);
-    return (n);
+    return n;
 }

--- a/lib/setgid.cpp
+++ b/lib/setgid.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int setgid(grp)
-int grp;
-{
-    return callm1(MM, SETGID, grp, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Set the group ID of the calling process.
+PUBLIC int setgid(int grp) { return callm1(MM, SETGID, grp, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/setuid.cpp
+++ b/lib/setuid.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int setuid(usr)
-int usr;
-{
-    return callm1(MM, SETUID, usr, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-}
+// Set the user ID of the calling process.
+PUBLIC int setuid(int usr) { return callm1(MM, SETUID, usr, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }

--- a/lib/stat.cpp
+++ b/lib/stat.cpp
@@ -1,10 +1,9 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int stat(name, buffer)
-char *name;
-char *buffer;
-{
+// Retrieve file status into 'buffer'.
+PUBLIC int stat(const char *name, char *buffer) {
     int n;
-    n = callm1(FS, STAT, len(name), 0, 0, name, buffer, NIL_PTR);
-    return (n);
+    n = callm1(FS, STAT, len(const_cast<char *>(name)), 0, 0, const_cast<char *>(name), buffer,
+               NIL_PTR);
+    return n;
 }

--- a/lib/time.cpp
+++ b/lib/time.cpp
@@ -1,17 +1,16 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC long time(tp)
-long *tp;
-{
+// Obtain the current system time.
+PUBLIC long time(long *tp) {
     int k;
     long l;
     k = callm1(FS, TIME, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     if (M.m_type < 0 || k != OK) {
         errno = -M.m_type;
-        return (-1L);
+        return -1L;
     }
     l = M.m2_l1;
     if (tp != (long *)0)
         *tp = l;
-    return (l);
+    return l;
 }

--- a/lib/umount.cpp
+++ b/lib/umount.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int umount(name)
-char *name;
-{
-    return callm3(FS, UMOUNT, 0, name);
-}
+// Unmount the file system named 'name'.
+PUBLIC int umount(const char *name) { return callm3(FS, UMOUNT, 0, const_cast<char *>(name)); }

--- a/lib/unlink.cpp
+++ b/lib/unlink.cpp
@@ -1,7 +1,4 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int unlink(name)
-char *name;
-{
-    return callm3(FS, UNLINK, 0, name);
-}
+// Remove a directory entry.
+PUBLIC int unlink(const char *name) { return callm3(FS, UNLINK, 0, const_cast<char *>(name)); }

--- a/lib/utime.cpp
+++ b/lib/utime.cpp
@@ -1,12 +1,10 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int utime(name, timp)
-char *name;
-long timp[2];
-{
-    M.m2_i1 = len(name);
+// Set file access and modification times.
+PUBLIC int utime(const char *name, long timp[2]) {
+    M.m2_i1 = len(const_cast<char *>(name));
     M.m2_l1 = timp[0];
     M.m2_l2 = timp[1];
-    M.m2_p1 = name;
+    M.m2_p1 = const_cast<char *>(name);
     return callx(FS, UTIME);
 }

--- a/tools/mkfs.cpp
+++ b/tools/mkfs.cpp
@@ -102,7 +102,8 @@ char *argv[];
     if (argc != 3 && argc != 4)
         badusage = 1;
     if (stat(argv[argc - 1], &statbuf) == 0) {
-        if ((statbuf.st_mode & S_IFMT) != S_IFREG)
+        if ((statbuf.st_mode & FileMode::S_IFMT) !=
+            static_cast<unsigned short>(FileMode::S_IFREG))
             badusage = 1;
     }
     if (badusage) {


### PR DESCRIPTION
## Summary
- convert several libc wrappers from K&R style to modern C++
- replace deprecated parameter names and add brief comments
- update stdio header and prototypes
- implement small fixes in brk and ioctl utilities

## Testing
- `make` *(fails: lib/crypt.cpp compile error)*

------
https://chatgpt.com/codex/tasks/task_e_683a1211e1b4833180b1ce88ff46b280