### PR TITLE
Refactor system call numbers to enum class

### DIFF
--- a/fs/misc.cpp
+++ b/fs/misc.cpp
@@ -210,11 +210,11 @@ PUBLIC int do_set() {
         return (ERROR);
 
     tfp = &fproc[slot1];
-    if (fs_call == SETUID) {
+    if (fs_call == static_cast<int>(SysCall::SETUID)) {
         tfp->fp_realuid = (uid)real_user_id;
         tfp->fp_effuid = (uid)eff_user_id;
     }
-    if (fs_call == SETGID) {
+    if (fs_call == static_cast<int>(SysCall::SETGID)) {
         tfp->fp_effgid = (gid)eff_grp_id;
         tfp->fp_realgid = (gid)real_grp_id;
     }

--- a/fs/pipe.cpp
+++ b/fs/pipe.cpp
@@ -109,7 +109,7 @@ register file_pos *position; /* pointer to current file position */
 
                 /* If need be, activate sleeping writer. */
                 if (susp_count > 0)
-                    release(rip, WRITE, 1);
+                    release(rip, static_cast<int>(SysCall::WRITE), 1);
             }
             return (0);
         }
@@ -119,7 +119,7 @@ register file_pos *position; /* pointer to current file position */
             return (ErrorCode::EFBIG);
         if (find_filp(rip, R_BIT) == NIL_FILP) {
             /* Tell MM to generate a SIGPIPE signal. */
-            mess.m_type = KSIG;
+            mess.m_type = static_cast<int>(SysCall::KSIG);
             mess.PROC1 = fp - fproc;
             mess.SIG_MAP = 1 << (SIGPIPE - 1);
             send(MM_PROC_NR, &mess);
@@ -133,7 +133,7 @@ register file_pos *position; /* pointer to current file position */
 
         /* Writing to an empty pipe.  Search for suspended reader. */
         if (*position == 0)
-            release(rip, READ, 1);
+            release(rip, static_cast<int>(SysCall::READ), 1);
     }
 
     return (1);

--- a/h/callnr.h
+++ b/h/callnr.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "callnr.hpp"

--- a/h/callnr.hpp
+++ b/h/callnr.hpp
@@ -1,53 +1,57 @@
 #pragma once
 // Modernized for C++17
 
-#define NCALLS 69 /* number of system calls allowed */
+// Number of system calls allowed.
+constexpr int NCALLS = 69;
 
-#define EXIT 1
-#define FORK 2
-#define READ 3
-#define WRITE 4
-#define OPEN 5
-#define CLOSE 6
-#define WAIT 7
-#define CREAT 8
-#define LINK 9
-#define UNLINK 10
-#define CHDIR 12
-#define TIME 13
-#define MKNOD 14
-#define CHMOD 15
-#define CHOWN 16
-#define BRK 17
-#define STAT 18
-#define LSEEK 19
-#define GETPID 20
-#define MOUNT 21
-#define UMOUNT 22
-#define SETUID 23
-#define GETUID 24
-#define STIME 25
-#define ALARM 27
-#define FSTAT 28
-#define PAUSE 29
-#define UTIME 30
-#define ACCESS 33
-#define SYNC 36
-#define KILL 37
-#define DUP 41
-#define PIPE 42
-#define TIMES 43
-#define SETGID 46
-#define GETGID 47
-#define SIGNAL 48
-#define IOCTL 54
-#define EXEC 59
-#define UMASK 60
-#define CHROOT 61
+// Enumeration of all kernel-visible system calls.
+enum class SysCall : int {
+    EXIT = 1,    ///< exit
+    FORK = 2,    ///< fork
+    READ = 3,    ///< read
+    WRITE = 4,   ///< write
+    OPEN = 5,    ///< open
+    CLOSE = 6,   ///< close
+    WAIT = 7,    ///< wait
+    CREAT = 8,   ///< creat
+    LINK = 9,    ///< link
+    UNLINK = 10, ///< unlink
+    CHDIR = 12,  ///< change directory
+    TIME = 13,   ///< get time
+    MKNOD = 14,  ///< make node
+    CHMOD = 15,  ///< change mode
+    CHOWN = 16,  ///< change owner
+    BRK = 17,    ///< adjust data segment
+    STAT = 18,   ///< get file status
+    LSEEK = 19,  ///< seek
+    GETPID = 20, ///< get process id
+    MOUNT = 21,  ///< mount file system
+    UMOUNT = 22, ///< unmount file system
+    SETUID = 23, ///< set user id
+    GETUID = 24, ///< get user id
+    STIME = 25,  ///< set time
+    ALARM = 27,  ///< alarm clock
+    FSTAT = 28,  ///< file status
+    PAUSE = 29,  ///< pause
+    UTIME = 30,  ///< change file times
+    ACCESS = 33, ///< access check
+    SYNC = 36,   ///< sync disks
+    KILL = 37,   ///< kill process
+    DUP = 41,    ///< duplicate file descriptor
+    PIPE = 42,   ///< create pipe
+    TIMES = 43,  ///< process times
+    SETGID = 46, ///< set group id
+    GETGID = 47, ///< get group id
+    SIGNAL = 48, ///< signal operations
+    IOCTL = 54,  ///< device ioctl
+    EXEC = 59,   ///< execute program
+    UMASK = 60,  ///< set file creation mask
+    CHROOT = 61, ///< change root
 
-/* The following are not system calls, but are processed like them. */
-#define KSIG 64       /* kernel detected a signal */
-#define UNPAUSE 65    /* to MM or FS: check for ErrorCode::EINTR */
-#define BRK2 66       /* to MM: used to say how big FS & INIT are */
-#define REVIVE 67     /* to FS: revive a sleeping process */
-#define TASK_REPLY 68 /* to FS: reply code from tty task */
+    // Processed like system calls but not part of the user API.
+    KSIG = 64,      ///< kernel detected signal
+    UNPAUSE = 65,   ///< check for EINTR
+    BRK2 = 66,      ///< memory map setup
+    REVIVE = 67,    ///< revive sleeping process
+    TASK_REPLY = 68 ///< tty task reply
+};

--- a/kernel/system.cpp
+++ b/kernel/system.cpp
@@ -469,7 +469,7 @@ int proc_nr; /* MM_PROC_NR or FS_PROC_NR */
     /* MM is waiting for new input.  Find a process with pending signals. */
     for (rp = proc_addr(0); rp < proc_addr(NR_PROCS); rp++)
         if (rp->p_pending != 0) {
-            m.m_type = KSIG;
+            m.m_type = static_cast<int>(SysCall::KSIG);
             m.PROC1 = rp - proc - NR_TASKS;
             m.SIG_MAP = rp->p_pending;
             sig_procs--;

--- a/lib/access.cpp
+++ b/lib/access.cpp
@@ -4,5 +4,5 @@ PUBLIC int access(name, mode)
 char *name;
 int mode;
 {
-    return callm3(FS, ACCESS, mode, name);
+    return callm3(FS, static_cast<int>(SysCall::ACCESS), mode, name);
 }

--- a/lib/alarm.cpp
+++ b/lib/alarm.cpp
@@ -3,5 +3,5 @@
 PUBLIC int alarm(sec)
 unsigned sec;
 {
-    return callm1(MM, ALARM, (int)sec, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(MM, static_cast<int>(SysCall::ALARM), (int)sec, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/brk2.cpp
+++ b/lib/brk2.cpp
@@ -5,5 +5,5 @@ PUBLIC void brk2(void) {
     char *p1, *p2;
 
     p1 = (char *)get_size();
-    callm1(MM, BRK2, 0, 0, 0, p1, p2, NIL_PTR);
+    callm1(MM, static_cast<int>(SysCall::BRK2), 0, 0, 0, p1, p2, NIL_PTR);
 }

--- a/lib/chdir.cpp
+++ b/lib/chdir.cpp
@@ -3,5 +3,5 @@
 PUBLIC int chdir(name)
 char *name;
 {
-    return callm3(FS, CHDIR, 0, name);
+    return callm3(FS, static_cast<int>(SysCall::CHDIR), 0, name);
 }

--- a/lib/chmod.cpp
+++ b/lib/chmod.cpp
@@ -4,5 +4,5 @@ PUBLIC int chmod(name, mode)
 char *name;
 int mode;
 {
-    return callm3(FS, CHMOD, mode, name);
+    return callm3(FS, static_cast<int>(SysCall::CHMOD), mode, name);
 }

--- a/lib/chown.cpp
+++ b/lib/chown.cpp
@@ -4,5 +4,6 @@ PUBLIC int chown(name, owner, grp)
 char *name;
 int owner, grp;
 {
-    return callm1(FS, CHOWN, len(name), owner, grp, name, NIL_PTR, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::CHOWN), len(name), owner, grp, name, NIL_PTR,
+                  NIL_PTR);
 }

--- a/lib/chroot.cpp
+++ b/lib/chroot.cpp
@@ -3,5 +3,5 @@
 PUBLIC int chroot(name)
 char *name;
 {
-    return callm3(FS, CHROOT, 0, name);
+    return callm3(FS, static_cast<int>(SysCall::CHROOT), 0, name);
 }

--- a/lib/close.cpp
+++ b/lib/close.cpp
@@ -3,5 +3,5 @@
 PUBLIC int close(fd)
 int fd;
 {
-    return callm1(FS, CLOSE, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::CLOSE), fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/dup.cpp
+++ b/lib/dup.cpp
@@ -3,5 +3,5 @@
 PUBLIC int dup(fd)
 int fd;
 {
-    return callm1(FS, DUP, fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::DUP), fd, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/dup2.cpp
+++ b/lib/dup2.cpp
@@ -3,5 +3,5 @@
 PUBLIC int dup2(fd, fd2)
 int fd, fd2;
 {
-    return callm1(FS, DUP, fd + 0100, fd2, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::DUP), fd + 0100, fd2, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/exit.cpp
+++ b/lib/exit.cpp
@@ -3,5 +3,5 @@
 PUBLIC int exit(status)
 int status;
 {
-    return callm1(MM, EXIT, status, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(MM, static_cast<int>(SysCall::EXIT), status, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/fork.cpp
+++ b/lib/fork.cpp
@@ -1,3 +1,5 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int fork() { return callm1(MM, FORK, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }
+PUBLIC int fork() {
+    return callm1(MM, static_cast<int>(SysCall::FORK), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+}

--- a/lib/fstat.cpp
+++ b/lib/fstat.cpp
@@ -5,6 +5,6 @@ int fd;
 char *buffer;
 {
     int n;
-    n = callm1(FS, FSTAT, fd, 0, 0, buffer, NIL_PTR, NIL_PTR);
+    n = callm1(FS, static_cast<int>(SysCall::FSTAT), fd, 0, 0, buffer, NIL_PTR, NIL_PTR);
     return (n);
 }

--- a/lib/getegid.cpp
+++ b/lib/getegid.cpp
@@ -2,7 +2,7 @@
 
 PUBLIC gid getegid() {
     int k;
-    k = callm1(MM, GETGID, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    k = callm1(MM, static_cast<int>(SysCall::GETGID), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     if (k < 0)
         return ((gid)k);
     return ((gid)M.m2_i1);

--- a/lib/geteuid.cpp
+++ b/lib/geteuid.cpp
@@ -2,7 +2,7 @@
 
 PUBLIC uid geteuid() {
     int k;
-    k = callm1(MM, GETUID, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    k = callm1(MM, static_cast<int>(SysCall::GETUID), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     if (k < 0)
         return ((uid)k);
     return ((uid)M.m2_i1);

--- a/lib/getgid.cpp
+++ b/lib/getgid.cpp
@@ -2,6 +2,6 @@
 
 PUBLIC gid getgid() {
     int k;
-    k = callm1(MM, GETGID, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    k = callm1(MM, static_cast<int>(SysCall::GETGID), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     return ((gid)k);
 }

--- a/lib/getuid.cpp
+++ b/lib/getuid.cpp
@@ -2,6 +2,6 @@
 
 PUBLIC uid getuid() {
     int k;
-    k = callm1(MM, GETUID, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    k = callm1(MM, static_cast<int>(SysCall::GETUID), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     return ((uid)k);
 }

--- a/lib/ioctl.cpp
+++ b/lib/ioctl.cpp
@@ -23,7 +23,7 @@ union {
         kill = u.argp->sg_kill & 0377;
         M.TTY_SPEK = (erase << 8) | kill;
         M.TTY_FLAGS = u.argp->sg_flags;
-        n = callx(FS, IOCTL);
+        n = callx(FS, static_cast<int>(SysCall::IOCTL));
         return (n);
 
     case TIOCSETC:
@@ -35,18 +35,18 @@ union {
         brk = u.argt->t_brkc & 0377; /* not used at the moment */
         M.TTY_SPEK = (intr << 24) | (quit << 16) | (xon << 8) | (xoff << 0);
         M.TTY_FLAGS = (eof << 8) | (brk << 0);
-        n = callx(FS, IOCTL);
+        n = callx(FS, static_cast<int>(SysCall::IOCTL));
         return (n);
 
     case TIOCGETP:
-        n = callx(FS, IOCTL);
+        n = callx(FS, static_cast<int>(SysCall::IOCTL));
         u.argp->sg_erase = (M.TTY_SPEK >> 8) & 0377;
         u.argp->sg_kill = (M.TTY_SPEK >> 0) & 0377;
         u.argp->sg_flags = M.TTY_FLAGS;
         return (n);
 
     case TIOCGETC:
-        n = callx(FS, IOCTL);
+        n = callx(FS, static_cast<int>(SysCall::IOCTL));
         u.argt->t_intrc = (M.TTY_SPEK >> 24) & 0377;
         u.argt->t_quitc = (M.TTY_SPEK >> 16) & 0377;
         u.argt->t_startc = (M.TTY_SPEK >> 8) & 0377;

--- a/lib/kill.cpp
+++ b/lib/kill.cpp
@@ -4,5 +4,5 @@ PUBLIC int kill(proc, sig)
 int proc; /* which process is to be sent the signal */
 int sig;  /* signal number */
 {
-    return callm1(MM, KILL, proc, sig, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(MM, static_cast<int>(SysCall::KILL), proc, sig, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/link.cpp
+++ b/lib/link.cpp
@@ -3,5 +3,6 @@
 PUBLIC int link(name, name2)
 char *name, *name2;
 {
-    return callm1(FS, LINK, len(name), len(name2), 0, name, name2, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::LINK), len(name), len(name2), 0, name, name2,
+                  NIL_PTR);
 }

--- a/lib/mknod.cpp
+++ b/lib/mknod.cpp
@@ -4,5 +4,6 @@ PUBLIC int mknod(name, mode, addr)
 char *name;
 int mode, addr;
 {
-    return callm1(FS, MKNOD, len(name), mode, addr, name, NIL_PTR, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::MKNOD), len(name), mode, addr, name, NIL_PTR,
+                  NIL_PTR);
 }

--- a/lib/mount.cpp
+++ b/lib/mount.cpp
@@ -4,5 +4,6 @@ PUBLIC int mount(special, name, rwflag)
 char *name, *special;
 int rwflag;
 {
-    return callm1(FS, MOUNT, len(special), len(name), rwflag, special, name, NIL_PTR);
+    return callm1(FS, static_cast<int>(SysCall::MOUNT), len(special), len(name), rwflag, special,
+                  name, NIL_PTR);
 }

--- a/lib/open.cpp
+++ b/lib/open.cpp
@@ -4,5 +4,5 @@ PUBLIC int open(name, mode)
 char *name;
 int mode;
 {
-    return callm3(FS, OPEN, mode, name);
+    return callm3(FS, static_cast<int>(SysCall::OPEN), mode, name);
 }

--- a/lib/pipe.cpp
+++ b/lib/pipe.cpp
@@ -4,7 +4,7 @@ PUBLIC int pipe(fild)
 int fild[2];
 {
     int k;
-    k = callm1(FS, PIPE, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    k = callm1(FS, static_cast<int>(SysCall::PIPE), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
     if (k >= 0) {
         fild[0] = M.m1_i1;
         fild[1] = M.m1_i2;

--- a/lib/read.cpp
+++ b/lib/read.cpp
@@ -6,6 +6,6 @@ char *buffer;
 int nbytes;
 {
     int n;
-    n = callm1(FS, READ, fd, nbytes, 0, buffer, NIL_PTR, NIL_PTR);
+    n = callm1(FS, static_cast<int>(SysCall::READ), fd, nbytes, 0, buffer, NIL_PTR, NIL_PTR);
     return (n);
 }

--- a/lib/setgid.cpp
+++ b/lib/setgid.cpp
@@ -3,5 +3,5 @@
 PUBLIC int setgid(grp)
 int grp;
 {
-    return callm1(MM, SETGID, grp, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(MM, static_cast<int>(SysCall::SETGID), grp, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/setuid.cpp
+++ b/lib/setuid.cpp
@@ -3,5 +3,5 @@
 PUBLIC int setuid(usr)
 int usr;
 {
-    return callm1(MM, SETUID, usr, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+    return callm1(MM, static_cast<int>(SysCall::SETUID), usr, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
 }

--- a/lib/signal.cpp
+++ b/lib/signal.cpp
@@ -20,6 +20,6 @@ PUBLIC sighandler_t signal(int signr, sighandler_t func) {
     vectab[signr - 1] = func;
     M.m6_i1 = signr;
     M.m6_f1 = ((func == SIG_IGN || func == SIG_DFL) ? func : begsig);
-    r = callx(MM, SIGNAL);
+    r = callx(MM, static_cast<int>(SysCall::SIGNAL));
     return ((r < 0 ? (sighandler_t)r : old));
 }

--- a/lib/stime.cpp
+++ b/lib/stime.cpp
@@ -4,5 +4,5 @@ PUBLIC int stime(top)
 long *top;
 {
     M.m2_l1 = *top;
-    return callx(FS, STIME);
+    return callx(FS, static_cast<int>(SysCall::STIME));
 }

--- a/lib/sync.cpp
+++ b/lib/sync.cpp
@@ -1,3 +1,5 @@
 #include "../include/lib.hpp" // C++17 header
 
-PUBLIC int sync() { return callm1(FS, SYNC, 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR); }
+PUBLIC int sync() {
+    return callm1(FS, static_cast<int>(SysCall::SYNC), 0, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
+}

--- a/lib/write.cpp
+++ b/lib/write.cpp
@@ -4,5 +4,6 @@
 /* Perform the write() system call through the message interface. */
 ssize_t write(int fd, const void *buffer, size_t nbytes) {
     /* Delegates to the low level message based syscall wrapper. */
-    return (ssize_t)callm1(FS, WRITE, fd, (int)nbytes, 0, (char *)buffer, NIL_PTR, NIL_PTR);
+    return (ssize_t)callm1(FS, static_cast<int>(SysCall::WRITE), fd, (int)nbytes, 0, (char *)buffer,
+                           NIL_PTR, NIL_PTR);
 }

--- a/mm/exec.cpp
+++ b/mm/exec.cpp
@@ -64,10 +64,11 @@ PUBLIC int do_exec() {
     dst = (vir_bytes)u.name_buf;
     r = mem_copy(who, D, (long)src, MM_PROC_NR, D, (long)dst, (long)exec_len);
     if (r != OK)
-        return (r);                          /* file name not in user data segment */
-    tell_fs(CHDIR, who, 0, 0);               /* temporarily switch to user's directory */
-    fd = allowed(u.name_buf, &s_buf, X_BIT); /* is file executable? */
-    tell_fs(CHDIR, 0, 1, 0);                 /* switch back to MM's own directory */
+        return (r); /* file name not in user data segment */
+    tell_fs(static_cast<int>(SysCall::CHDIR), who, 0,
+            0);                                         /* temporarily switch to user's directory */
+    fd = allowed(u.name_buf, &s_buf, X_BIT);            /* is file executable? */
+    tell_fs(static_cast<int>(SysCall::CHDIR), 0, 1, 0); /* switch back to MM's own directory */
     if (fd < 0)
         return (fd); /* file was not executable */
 
@@ -111,11 +112,11 @@ PUBLIC int do_exec() {
     /* Take care of setuid/setgid bits. */
     if (s_buf.st_mode & I_SET_UID_BIT) {
         rmp->mp_effuid = s_buf.st_uid;
-        tell_fs(SETUID, who, (int)rmp->mp_realuid, (int)rmp->mp_effuid);
+        tell_fs(static_cast<int>(SysCall::SETUID), who, (int)rmp->mp_realuid, (int)rmp->mp_effuid);
     }
     if (s_buf.st_mode & I_SET_GID_BIT) {
         rmp->mp_effgid = s_buf.st_gid;
-        tell_fs(SETGID, who, (int)rmp->mp_realgid, (int)rmp->mp_effgid);
+        tell_fs(static_cast<int>(SysCall::SETGID), who, (int)rmp->mp_realgid, (int)rmp->mp_effgid);
     }
 
     /* Fix up some 'mproc' fields and tell kernel that exec is done. */

--- a/mm/forkexit.cpp
+++ b/mm/forkexit.cpp
@@ -103,7 +103,7 @@ PUBLIC int do_fork() {
 
     /* Tell kernel and file system about the (now successful) FORK. */
     sys_fork(who, child_nr, rmc->mp_pid);
-    tell_fs(FORK, who, child_nr, 0);
+    tell_fs(static_cast<int>(SysCall::FORK), who, child_nr, 0);
 
     /* Report child's memory map to kernel. */
     sys_newmap(child_nr, rmc->mp_seg);
@@ -151,7 +151,8 @@ int exit_status;            /* the process' exit status (for parent) */
 
     /* Tell the kernel and FS that the process is no longer runnable. */
     sys_xit(rmp->mp_parent, rmp - mproc);
-    tell_fs(EXIT, rmp - mproc, 0, 0); /* file system can free the proc slot */
+    tell_fs(static_cast<int>(SysCall::EXIT), rmp - mproc, 0,
+            0); /* file system can free the proc slot */
 }
 
 /*===========================================================================*

--- a/mm/getset.cpp
+++ b/mm/getset.cpp
@@ -25,36 +25,36 @@ PUBLIC int do_getset() {
     register int r;
 
     switch (mm_call) {
-    case GETUID:
+    case static_cast<int>(SysCall::GETUID):
         r = rmp->mp_realuid;
         result2 = rmp->mp_effuid;
         break;
 
-    case GETGID:
+    case static_cast<int>(SysCall::GETGID):
         r = rmp->mp_realgid;
         result2 = rmp->mp_effgid;
         break;
 
-    case GETPID:
+    case static_cast<int>(SysCall::GETPID):
         r = mproc[who].mp_pid;
         result2 = mproc[rmp->mp_parent].mp_pid;
         break;
 
-    case SETUID:
+    case static_cast<int>(SysCall::SETUID):
         if (rmp->mp_realuid != usr_id && rmp->mp_effuid != SUPER_USER)
             return (ErrorCode::EPERM);
         rmp->mp_realuid = usr_id;
         rmp->mp_effuid = usr_id;
-        tell_fs(SETUID, who, usr_id, usr_id);
+        tell_fs(static_cast<int>(SysCall::SETUID), who, usr_id, usr_id);
         r = OK;
         break;
 
-    case SETGID:
+    case static_cast<int>(SysCall::SETGID):
         if (rmp->mp_realgid != grpid && rmp->mp_effuid != SUPER_USER)
             return (ErrorCode::EPERM);
         rmp->mp_realgid = grpid;
         rmp->mp_effgid = grpid;
-        tell_fs(SETGID, who, grpid, grpid);
+        tell_fs(static_cast<int>(SysCall::SETGID), who, grpid, grpid);
         r = OK;
         break;
     }

--- a/mm/main.cpp
+++ b/mm/main.cpp
@@ -59,7 +59,7 @@ PUBLIC main() {
         /* Send the results back to the user to indicate completion. */
         if (dont_reply)
             continue; /* no reply for EXIT and WAIT */
-        if (mm_call == EXEC && error == OK)
+        if (mm_call == static_cast<int>(SysCall::EXEC) && error == OK)
             continue;
         reply(who, error, result2, res_ptr);
     }

--- a/mm/signal.cpp
+++ b/mm/signal.cpp
@@ -319,7 +319,7 @@ int pro; /* which process number */
     }
 
     /* Process is not hanging on an MM call.  Ask FS to take a look. */
-    tell_fs(UNPAUSE, pro, 0, 0);
+    tell_fs(static_cast<int>(SysCall::UNPAUSE), pro, 0, 0);
 
     return;
 }
@@ -342,7 +342,7 @@ register struct mproc *rmp; /* whose core is to be dumped */
 
     /* Change to working directory of dumpee. */
     slot = rmp - mproc;
-    tell_fs(CHDIR, slot, 0, 0);
+    tell_fs(static_cast<int>(SysCall::CHDIR), slot, 0, 0);
 
     /* Can core file be written? */
     if (rmp->mp_realuid != rmp->mp_effuid)
@@ -362,7 +362,7 @@ register struct mproc *rmp; /* whose core is to be dumped */
     if (s >= 0 && (r >= 0 || r == ErrorCode::ENOENT)) {
         /* Either file is writable or it doesn't exist & dir is writable */
         r = creat(core_name, CORE_MODE);
-        tell_fs(CHDIR, 0, 1, 0); /* go back to MM's own dir */
+        tell_fs(static_cast<int>(SysCall::CHDIR), 0, 1, 0); /* go back to MM's own dir */
         if (r < 0)
             return;
         rmp->mp_sigstatus |= DUMPED;
@@ -397,7 +397,7 @@ register struct mproc *rmp; /* whose core is to be dumped */
             }
         }
     } else {
-        tell_fs(CHDIR, 0, 1, 0); /* go back to MM's own dir */
+        tell_fs(static_cast<int>(SysCall::CHDIR), 0, 1, 0); /* go back to MM's own dir */
         close(r);
         return;
     }

--- a/mm/utility.cpp
+++ b/mm/utility.cpp
@@ -143,6 +143,6 @@ PUBLIC void panic(const char *format, int num) {
     if (num != NO_NUM)
         printf("%d", num);
     printf("\n");
-    tell_fs(SYNC, 0, 0, 0); /* flush the cache to the disk */
+    tell_fs(static_cast<int>(SysCall::SYNC), 0, 0, 0); /* flush the cache to the disk */
     sys_abort();
 }


### PR DESCRIPTION
## Summary
- replace `#define` system call numbers with `enum class SysCall`
- add `constexpr int NCALLS = 69`
- update all user code to use `SysCall::NAME`
- keep compatibility via new `callnr.h` wrapper

## Testing
- `make -s clean >/dev/null && make -s >/dev/null && ctest -V` *(fails: unknown type name 'name' in access.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_683a11f6b300833191c5e28880a0fd5b