### PR TITLE
Replace macros with VmFlags enum

### DIFF
--- a/include/vm.hpp
+++ b/include/vm.hpp
@@ -10,31 +10,53 @@
 #include "../h/const.h"
 #include "paging.hpp"
 
-/* Flags for virtual memory regions */
-#define VM_READ 0x1
-#define VM_WRITE 0x2
-#define VM_EXEC 0x4
-#define VM_PRIVATE 0x8
-#define VM_SHARED 0x10
-#define VM_ANON 0x20
+/* Enumerates flags describing permissions and properties for a
+ * virtual memory region.  The values are kept compatible with the
+ * original macro definitions.
+ */
+enum class VmFlags : int {
+    VM_READ = 0x1,    /* region is readable */
+    VM_WRITE = 0x2,   /* region is writable */
+    VM_EXEC = 0x4,    /* region is executable */
+    VM_PRIVATE = 0x8, /* region is private */
+    VM_SHARED = 0x10, /* region is shared */
+    VM_ANON = 0x20    /* region is anonymous */
+};
+
+/* Enable bitwise operations for VmFlags. */
+inline constexpr VmFlags operator|(VmFlags lhs, VmFlags rhs) {
+    return static_cast<VmFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
+}
+inline constexpr VmFlags operator&(VmFlags lhs, VmFlags rhs) {
+    return static_cast<VmFlags>(static_cast<int>(lhs) & static_cast<int>(rhs));
+}
+inline VmFlags &operator|=(VmFlags &lhs, VmFlags rhs) {
+    lhs = lhs | rhs;
+    return lhs;
+}
+inline VmFlags &operator&=(VmFlags &lhs, VmFlags rhs) {
+    lhs = lhs & rhs;
+    return lhs;
+}
 
 #define VM_MAX_AREAS 16
 
+/* Describes a contiguous virtual memory area owned by a process. */
 struct vm_area {
     virt_addr64 start; /* inclusive start address */
     virt_addr64 end;   /* exclusive end address */
-    int flags;         /* protection flags */
+    VmFlags flags;     /* protection flags */
 };
 
 struct vm_proc {
-    struct vm_area areas[VM_MAX_AREAS];
-    int area_count;
+    struct vm_area areas[VM_MAX_AREAS]; /* list of owned areas */
+    int area_count;                     /* number of valid entries */
 };
 
 void vm_init(void);
-void *vm_alloc(u64_t bytes, int flags);
+void *vm_alloc(u64_t bytes, VmFlags flags);
 void vm_handle_fault(int proc, virt_addr64 addr);
 int vm_fork(int parent, int child);
-void *vm_mmap(int proc, void *addr, u64_t length, int flags);
+void *vm_mmap(int proc, void *addr, u64_t length, VmFlags flags);
 
 #endif /* VM_H */

--- a/mm/vm.cpp
+++ b/mm/vm.cpp
@@ -1,4 +1,4 @@
-#include "../include/vm.h"
+#include "../include/vm.hpp"
 #include "const.hpp"
 #include "mproc.hpp"
 
@@ -46,7 +46,7 @@ PUBLIC void vm_init(void) {
  * bytes: size in bytes to allocate.
  * flags: protection flags (unused).
  */
-PUBLIC void *vm_alloc(u64_t bytes, int flags) {
+PUBLIC void *vm_alloc(u64_t bytes, VmFlags flags) {
     virt_addr64 base;
     unsigned long pages;
 
@@ -73,7 +73,7 @@ PUBLIC void vm_handle_fault(int proc, virt_addr64 addr) {
         struct vm_area *a = &p->areas[p->area_count++];
         a->start = addr & ~(PAGE_SIZE_4K - 1);
         a->end = a->start + PAGE_SIZE_4K;
-        a->flags = VM_READ | VM_WRITE | VM_PRIVATE;
+        a->flags = VmFlags::VM_READ | VmFlags::VM_WRITE | VmFlags::VM_PRIVATE;
     }
 }
 
@@ -98,7 +98,7 @@ PUBLIC int vm_fork(int parent, int child) {
  * length: length of mapping in bytes.
  * flags:  mapping flags.
  */
-PUBLIC void *vm_mmap(int proc, void *addr, u64_t length, int flags) {
+PUBLIC void *vm_mmap(int proc, void *addr, u64_t length, VmFlags flags) {
     struct vm_proc *p = &vm_proc_table[proc];
     virt_addr64 base = (virt_addr64)addr;
 


### PR DESCRIPTION
## Summary
- modernize VM flag constants by introducing `VmFlags` enum class
- add bitwise operators for `VmFlags`
- document each field in VM structs
- update memory subsystem to use `VmFlags`
- format code with clang-format

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: error in const.hpp)*
- `ctest --output-on-failure` *(fails: executables not built)*

------
https://chatgpt.com/codex/tasks/task_e_683a1bf176948331bf9ec3481f375e80