### PR TITLE
Modernize regexp definitions

### DIFF
--- a/commands/grep.cpp
+++ b/commands/grep.cpp
@@ -123,7 +123,7 @@ static void match(char *name, regexp *exp) {
             pline(name, lineno, buf);
     }
 }
-static void regerror(char *s) {
+static void regerror(const char *s) {
     std_err("grep: ");
     std_err(s);
     std_err("\n");

--- a/commands/gres.cpp
+++ b/commands/gres.cpp
@@ -104,7 +104,7 @@ static void process(FILE *inf, regexp *exp, char *repstr) {
     }
 }
 
-void static void regerror(char *s) {
+static void regerror(const char *s) {
     std_err("gres: ");
     std_err(s);
     std_err("\n");

--- a/include/regexp.hpp
+++ b/include/regexp.hpp
@@ -10,21 +10,30 @@
  * Caveat:  this is V8 regexp(3) [actually, a reimplementation thereof],
  * not the System V one.
  */
-#define void int
-#define CHARBITS 0377
 #define strchr index
-#define NSUBEXP 10
-typedef struct regexp {
-    char *startp[NSUBEXP];
-    char *endp[NSUBEXP];
-    char regstart;   /* Internal use only. */
-    char reganch;    /* Internal use only. */
-    char *regmust;   /* Internal use only. */
-    int regmlen;     /* Internal use only. */
-    char program[1]; /* Unwarranted chumminess with compiler. */
-} regexp;
 
-extern regexp *regcomp(char *exp);
-extern int regexec(regexp *prog, char *string, int bolflag);
-extern void regsub(regexp *prog, char *source, char *dest);
-extern void regerror(char *s);
+/* Number of bits in a character, used by legacy UCHARAT macro. */
+inline constexpr int CHARBITS = 0377;
+
+/* Maximum number of parenthesized subexpressions supported. */
+inline constexpr int NSUBEXP = 10;
+
+/*
+ * Representation for compiled regular expressions.  The startp/endp
+ * arrays hold pointers to subexpression matches.  The reg* fields are
+ * used internally by the matcher to speed up execution.
+ */
+struct regexp {
+    char *startp[NSUBEXP]; ///< Pointers to start of matches.
+    char *endp[NSUBEXP];   ///< Pointers to end of matches.
+    char regstart;         ///< Required first character, or '\0'.
+    char reganch;          ///< If true, pattern is anchored.
+    char *regmust;         ///< Required substring within the match.
+    int regmlen;           ///< Length of regmust substring.
+    char program[1];       ///< Bytecode for the compiled pattern.
+};
+
+regexp *regcomp(const char *exp);
+int regexec(regexp *prog, const char *string, bool bolflag);
+void regsub(regexp *prog, const char *source, char *dest);
+void regerror(const char *s);

--- a/lib/regexp.cpp
+++ b/lib/regexp.cpp
@@ -26,9 +26,9 @@
  *	Andy Tanenbaum also made some changes.
  */
 
-#include "../include/regexp.h"
+#include "../include/regexp.hpp"
 #include "../include/lib.hpp" // C++17 header
-#include "../include/stdio.h"
+#include "../include/stdio.hpp"
 #include <string.h>
 #include <strings.h>
 
@@ -194,9 +194,7 @@ STATIC int mystrcspn();
  * Beware that the optimization-preparation code in here knows about some
  * of the structure of the compiled regexp.
  */
-regexp *regcomp(exp)
-char *exp;
-{
+regexp *regcomp(const char *exp) {
     register regexp *r;
     register char *scan;
     register char *longest;
@@ -688,12 +686,8 @@ STATIC char *regprop();
 /*
  - regexec - match a regexp against a string
  */
-int regexec(prog, string, bolflag)
-register regexp *prog;
-register char *string;
-int bolflag;
-{
-    register char *s;
+int regexec(regexp *prog, const char *string, bool bolflag) {
+    register const char *s;
 
     /* Be paranoid... */
     if (prog == NULL || string == NULL) {

--- a/lib/regsub.cpp
+++ b/lib/regsub.cpp
@@ -18,69 +18,63 @@
  *	3. Altered versions must be plainly marked as such, and must not
  *		be misrepresented as being the original software.
  */
-#include "../include/stdio.h"
-#include "../include/regexp.h"
+#include "../include/regexp.hpp"
+#include "../include/stdio.hpp"
 /*
  * The first byte of the regexp internal "program" is actually this magic
  * number; the start node begins in the second byte.
  */
-#define	MAGIC	0234
+#define MAGIC 0234
 
-
-#define CHARBITS 0377
 #ifndef CHARBITS
-#define	UCHARAT(p)	((int)*(unsigned char *)(p))
+#define UCHARAT(p) ((int)*(unsigned char *)(p))
 #else
-#define	UCHARAT(p)	((int)*(p)&CHARBITS)
+#define UCHARAT(p) ((int)*(p) & CHARBITS)
 #endif
 
 /*
  - regsub - perform substitutions after a regexp match
  */
-regsub(prog, source, dest)
-regexp *prog;
-char *source;
-char *dest;
-{
-	register char *src;
-	register char *dst;
-	register char c;
-	register int no;
-	register int len;
-	extern char *strncpy();
+void regsub(regexp *prog, const char *source, char *dest) {
+    register const char *src;
+    register char *dst;
+    register char c;
+    register int no;
+    register int len;
+    extern char *strncpy();
 
-	if (prog == NULL || source == NULL || dest == NULL) {
-		regerror("NULL parm to regsub");
-		return;
-	}
-	if (UCHARAT(prog->program) != MAGIC) {
-		regerror("damaged regexp fed to regsub");
-		return;
-	}
+    if (prog == NULL || source == NULL || dest == NULL) {
+        regerror("NULL parm to regsub");
+        return;
+    }
+    if (UCHARAT(prog->program) != MAGIC) {
+        regerror("damaged regexp fed to regsub");
+        return;
+    }
 
-	src = source;
-	dst = dest;
-	while ((c = *src++) != '\0') {
-		if (c == '&')
-			no = 0;
-		else if (c == '\\' && '0' <= *src && *src <= '9')
-			no = *src++ - '0';
-		else
-			no = -1;
+    src = source;
+    dst = dest;
+    while ((c = *src++) != '\0') {
+        if (c == '&')
+            no = 0;
+        else if (c == '\\' && '0' <= *src && *src <= '9')
+            no = *src++ - '0';
+        else
+            no = -1;
 
-		if (no < 0) {	/* Ordinary character. */
-			if (c == '\\' && (*src == '\\' || *src == '&'))
-				c = *src++;
-			*dst++ = c;
-		} else if (prog->startp[no] != NULL && prog->endp[no] != NULL) {
-			len = prog->endp[no] - prog->startp[no];
-			strncpy(dst, prog->startp[no], len);
-			dst += len;
-			if (len !=0 && *(dst-1) == '\0') { /* strncpy hit NUL. */
-				regerror("damaged match string");
-				return;
-			}
-		}
-	}
-	*dst++ = '\0';
+        if (no < 0) { /* Ordinary character. */
+            if (c == '\\' && (*src == '\\' || *src == '&'))
+                c = *src++;
+            *dst++ = c;
+        } else if (prog->startp[no] != NULL && prog->endp[no] != NULL) {
+            len = prog->endp[no] - prog->startp[no];
+            strncpy(dst, prog->startp[no], len);
+            dst += len;
+            if (len != 0 && *(dst - 1) == '\0') { /* strncpy hit NUL. */
+                regerror("damaged match string");
+                return;
+            }
+        }
+    }
+    *dst++ = '\0';
 }


### PR DESCRIPTION
## Summary
- drop `#define void int`
- use `inline constexpr` for `CHARBITS` and `NSUBEXP`
- document members of `regexp`
- update prototypes and definitions to modern C++
- adjust includes and formatting

## Testing
- `cmake -B build -S . -DCMAKE_C_COMPILER=cc -DCMAKE_CXX_COMPILER=g++`
- `cmake --build build` *(fails: expected nested-name-specifier before numeric constant)*

------
https://chatgpt.com/codex/tasks/task_e_683a1be7289c83318f1017c26094bc1c