### PR TITLE
Update setjmp wrapper and usage

### DIFF
--- a/commands/sh1.cpp
+++ b/commands/sh1.cpp
@@ -217,14 +217,15 @@ onecommand() {
     DELETE(cp);
     wdlist = 0;
     iolist = 0;
-    e.errpt = 0;
+    e.errpt = nullptr;
     e.linep = line;
     yynerrs = 0;
     multiline = 0;
     inparse = 1;
     if (talking)
         signal(SIGINT, onintr);
-    if (setjmp(failpt = m1) || yyparse() || intr) {
+    failpt = &m1;
+    if (setjmp(m1) || yyparse() || intr) {
         while (e.oenv)
             quitenv();
         scraphere();
@@ -252,7 +253,7 @@ onecommand() {
 }
 
 void fail() {
-    longjmp(failpt, 1);
+    longjmp(*failpt, 1);
     /* NOTREACHED */
 }
 
@@ -284,7 +285,7 @@ err(s) char *s;
     if (!talking)
         leave();
     if (e.errpt)
-        longjmp(e.errpt, 1);
+        longjmp(*e.errpt, 1);
     closeall();
     e.iop = e.iobase = iostack;
 }

--- a/commands/sh3.cpp
+++ b/commands/sh3.cpp
@@ -551,7 +551,7 @@ int (*f)();
     struct wdblock *swdlist;
     struct wdblock *siolist;
     jmp_buf ev, rt;
-    xint *ofail;
+    jmp_buf *ofail;
     int rv;
 
     areanum++;
@@ -560,13 +560,15 @@ int (*f)();
     otree = outtree;
     ofail = failpt;
     rv = -1;
-    if (newenv(setjmp(errpt = ev)) == 0) {
+    errpt = &ev;
+    if (newenv(setjmp(ev)) == 0) {
         wdlist = 0;
         iolist = 0;
         pushio(arg, f);
         e.iobase = e.iop;
         yynerrs = 0;
-        if (setjmp(failpt = rt) == 0 && yyparse() == 0)
+        failpt = &rt;
+        if (setjmp(rt) == 0 && yyparse() == 0)
             rv = execute(outtree, NOPIPE, NOPIPE, 0);
         quitenv();
     }
@@ -663,7 +665,7 @@ doexec(t) register struct op *t;
 {
     register i;
     jmp_buf ex;
-    xint *ofail;
+    jmp_buf *ofail;
 
     t->ioact = NULL;
     for (i = 0; (t->words[i] = t->words[i + 1]) != NULL; i++)
@@ -672,7 +674,8 @@ doexec(t) register struct op *t;
         return (1);
     execflg = 1;
     ofail = failpt;
-    if (setjmp(failpt = ex) == 0)
+    failpt = &ex;
+    if (setjmp(ex) == 0)
         execute(t, NOPIPE, NOPIPE, FEXEC);
     failpt = ofail;
     execflg = 0;

--- a/commands/sh4.cpp
+++ b/commands/sh4.cpp
@@ -37,7 +37,8 @@ register char **ap;
     inword++;
     wp = NULL;
     wb = NULL;
-    if (newenv(setjmp(errpt = ev)) == 0) {
+    errpt = &ev;
+    if (newenv(setjmp(ev)) == 0) {
         wb = addword((char *)0, wb); /* space for shell name, if command file */
         while (expand(*ap++, &wb, f))
             ;
@@ -104,7 +105,8 @@ register struct wdblock **wbp;
         *wbp = addword(cp, *wbp);
         return (1);
     }
-    if (newenv(setjmp(errpt = ev)) == 0) {
+    errpt = &ev;
+    if (newenv(setjmp(ev)) == 0) {
         PUSHIO(aword, cp, strchar);
         e.iobase = e.iop;
         while ((cp = blank(f)) && gflg == 0) {

--- a/commands/sh5.cpp
+++ b/commands/sh5.cpp
@@ -440,7 +440,8 @@ register char *s;
     bp = (struct block *)space(sizeof(*bp));
     if (bp == 0)
         return (0);
-    if (newenv(setjmp(errpt = ev)) == 0) {
+    errpt = &ev;
+    if (newenv(setjmp(ev)) == 0) {
         if (e.iop == iostack && e.iop->iofn == filechar) {
             pushio(e.iop->arg, filechar);
             e.iobase = e.iop;
@@ -513,7 +514,8 @@ herein(bp, xdoll) struct block *bp;
             char c;
             jmp_buf ev;
 
-            if (newenv(setjmp(errpt = ev)) == 0) {
+            errpt = &ev;
+            if (newenv(setjmp(ev)) == 0) {
                 PUSHIO(aword, bp->b_start, strchar);
                 setbase(e.iop);
                 while ((c = subgetc(0, 0)) != 0) {

--- a/include/setjmp.hpp
+++ b/include/setjmp.hpp
@@ -8,15 +8,21 @@
 #define SETJMP_H
 
 /*
- * Minimal jmp_buf representation used by the legacy Minix sources.
- * The buffer merely stores a pointer to the host jmp_buf allocated at
- * runtime in the wrapper implementation.
+ * Provide a thin wrapper around the C++ standard setjmp facilities so the
+ * legacy sources can continue to include this header without change.  The
+ * jmp_buf alias exposes the host representation from <csetjmp> while the
+ * wrapper functions simply delegate to std::setjmp and std::longjmp.
  */
-#define _JBLEN 3
-typedef int jmp_buf[_JBLEN];
 
-/* Prototypes for the host provided setjmp/longjmp functions. */
-int setjmp(void *env);
-void longjmp(void *env, int val);
+#include <csetjmp>
+
+using jmp_buf = std::jmp_buf; /* expose the standard buffer type */
+
+/*
+ * Delegate to the standard versions.  These are inline so calls are
+ * forwarded directly without additional overhead.
+ */
+inline int setjmp(jmp_buf env) { return std::setjmp(env); }
+inline void longjmp(jmp_buf env, int val) { std::longjmp(env, val); }
 
 #endif /* SETJMP_H */

--- a/include/sh.hpp
+++ b/include/sh.hpp
@@ -100,8 +100,8 @@ int execflg;
 int multiline;      /* \n changed to ; */
 struct op *outtree; /* result from parser */
 
-xint *failpt;
-xint *errpt;
+jmp_buf *failpt; /* last failure point */
+jmp_buf *errpt;  /* current error handler */
 
 struct brkcon {
     jmp_buf brkpt;
@@ -140,7 +140,7 @@ extern struct env {
     char *linep;
     struct io *iobase;
     struct io *iop;
-    xint *errpt;
+    jmp_buf *errpt; /* saved error jump buffer */
     int iofd;
     struct env *oenv;
 } e;

--- a/lib/minix/setjmp.cpp
+++ b/lib/minix/setjmp.cpp
@@ -1,21 +1,16 @@
-#include "../../include/setjmp.h"
+#include "../../include/setjmp.hpp"
 #include "../../include/lib.h"
-#include <stdlib.h>
+#include <csetjmp>
 
 /*
  * Alternate location for _setjmp/_longjmp used by certain Minix binaries.
  * Implementation identical to the generic versions.
  */
-PUBLIC int _setjmp(jmp_buf env) {
-    jmp_buf *real = safe_malloc(sizeof(jmp_buf));
-    *(jmp_buf **)env = real;
-    return setjmp(*real);
-}
+PUBLIC int _setjmp(jmp_buf env) { return std::setjmp(env); }
 
 PUBLIC void _longjmp(jmp_buf env, int val) {
-    jmp_buf *real = *(jmp_buf **)env;
     if (val == 0) {
         val = 1;
     }
-    longjmp(*real, val);
+    std::longjmp(env, val);
 }

--- a/lib/setjmp.cpp
+++ b/lib/setjmp.cpp
@@ -1,24 +1,22 @@
-#include "../include/setjmp.h"
+#include "../include/setjmp.hpp"
 #include "../include/lib.hpp" // C++17 header
-#include <stdlib.h>
+#include <csetjmp>
 
 /*
  * Portable implementation of _setjmp using the host C library.
  * The custom jmp_buf stores a pointer to the real jmp_buf.
  */
 PUBLIC int _setjmp(jmp_buf env) {
-    jmp_buf *real = safe_malloc(sizeof(jmp_buf));
-    *(jmp_buf **)env = real;
-    return setjmp(*real);
+    /* Simply forward to the standard facility. */
+    return std::setjmp(env);
 }
 
 /*
  * Portable implementation of _longjmp using the host C library.
  */
 PUBLIC void _longjmp(jmp_buf env, int val) {
-    jmp_buf *real = *(jmp_buf **)env;
     if (val == 0) {
         val = 1;
     }
-    longjmp(*real, val);
+    std::longjmp(env, val);
 }


### PR DESCRIPTION
## Summary
- modernize setjmp header
- wrap standard setjmp/longjmp
- use `jmp_buf*` in shell sources

## Testing
- `make` *(fails: expected nested-name-specifier before numeric constant)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683a1bf0940c8331baf54aceb48b15c8