### PR TITLE
Modernize shell macros

### DIFF
--- a/commands/sh1.cpp
+++ b/commands/sh1.cpp
@@ -244,7 +244,7 @@ onecommand() {
     if (!flag['n']) {
         if (talking)
             signal(SIGINT, onintr);
-        execute(outtree, NOPIPE, NOPIPE, 0);
+        execute(outtree, nullptr, nullptr, 0);
         intr = 0;
         if (talking)
             signal(SIGINT, SIG_IGN);

--- a/commands/sh2.cpp
+++ b/commands/sh2.cpp
@@ -89,9 +89,9 @@ int cf;
                 SYNTAXERR;
             if (t->type != TPAREN && t->type != TCOM) {
                 /* shell statement */
-                t = block(TPAREN, t, NOBLOCK, NOWORDS);
+                t = block(TPAREN, t, nullptr, nullptr);
             }
-            t = block(TPIPE, t, p, NOWORDS);
+            t = block(TPIPE, t, p, nullptr);
         }
         peeksym = c;
     }
@@ -107,7 +107,7 @@ static struct op *andor() {
         while ((c = yylex(0)) == LOGAND || c == LOGOR) {
             if ((p = pipeline(CONTIN)) == NULL)
                 SYNTAXERR;
-            t = block(c == LOGAND ? TAND : TOR, t, p, NOWORDS);
+            t = block(c == LOGAND ? TAND : TOR, t, p, nullptr);
         }
         peeksym = c;
     }
@@ -122,7 +122,7 @@ static struct op *c_list() {
     if (t != NULL) {
         while ((c = yylex(0)) == ';' || c == '&' || multiline && c == '\n') {
             if (c == '&')
-                t = block(TASYNC, t, NOBLOCK, NOWORDS);
+                t = block(TASYNC, t, nullptr, nullptr);
             if ((p = andor()) == NULL)
                 return (t);
             t = list(t, p);
@@ -193,7 +193,7 @@ int type, mark;
     t = c_list();
     musthave(mark, 0);
     multiline--;
-    return (block(type, t, NOBLOCK, NOWORDS));
+    return (block(type, t, nullptr, nullptr));
 }
 
 static struct op *command(cf)
@@ -375,7 +375,7 @@ static char **pattern() {
         cf = 0;
     } while ((c = yylex(0)) == '|');
     peeksym = c;
-    word(NOWORD);
+    word(nullptr);
     return (copyw());
 }
 
@@ -389,7 +389,7 @@ static char **wordlist() {
     startl = 0;
     while ((c = yylex(0)) == WORD)
         word(yylval.cppp);
-    word(NOWORD);
+    word(nullptr);
     peeksym = c;
     return (copyw());
 }
@@ -404,7 +404,7 @@ register struct op *t1, *t2;
         return (t2);
     if (t2 == NULL)
         return (t1);
-    return (block(TLIST, t1, t2, NOWORDS));
+    return (block(TLIST, t1, t2, nullptr));
 }
 
 static struct op *block(type, t1, t2, wp)
@@ -467,13 +467,13 @@ register struct op *t;
         t->ioact = NULL;
     if (t->type != TCOM) {
         if (t->type != TPAREN && t->ioact != NULL) {
-            t = block(TPAREN, t, NOBLOCK, NOWORDS);
+            t = block(TPAREN, t, nullptr, nullptr);
             t->ioact = t->left->ioact;
             t->left->ioact = NULL;
         }
         return (t);
     }
-    word(NOWORD);
+    word(nullptr);
     t->words = copyw();
     return (t);
 }

--- a/commands/sh3.cpp
+++ b/commands/sh3.cpp
@@ -270,7 +270,7 @@ int *pforked;
     for (i = FDBASE; i < NOFILE; i++)
         close(i);
     if (t->type == TPAREN)
-        exit(execute(t->left, NOPIPE, NOPIPE, FEXEC));
+        exit(execute(t->left, nullptr, nullptr, FEXEC));
     if (resetsig) {
         signal(SIGINT, SIG_DFL);
         signal(SIGQUIT, SIG_DFL);
@@ -567,7 +567,7 @@ int (*f)();
         e.iobase = e.iop;
         yynerrs = 0;
         if (setjmp(failpt = rt) == 0 && yyparse() == 0)
-            rv = execute(outtree, NOPIPE, NOPIPE, 0);
+            rv = execute(outtree, nullptr, nullptr, 0);
         quitenv();
     }
     wdlist = swdlist;
@@ -673,7 +673,7 @@ doexec(t) register struct op *t;
     execflg = 1;
     ofail = failpt;
     if (setjmp(failpt = ex) == 0)
-        execute(t, NOPIPE, NOPIPE, FEXEC);
+        execute(t, nullptr, nullptr, FEXEC);
     failpt = ofail;
     execflg = 0;
     return (1);


### PR DESCRIPTION
## Summary
- refactor shell header constants into `constexpr` values
- convert enum macros to real enums
- use `nullptr` for pointer constants and update shell code
- document core shell structs
- run clang-format

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683a1bebdec8833184064f57bb232c41