### PR TITLE
Replace macros with cctype helpers

### DIFF
--- a/commands/make.cpp
+++ b/commands/make.cpp
@@ -7,6 +7,7 @@
 #include "../include/lib.hpp" // C++17 header
 #include "errno.hpp"
 #include "stdio.hpp"
+#include <cctype>
 extern int errno;
 
 #ifdef LC
@@ -129,7 +130,6 @@ char *whoami = "Make";
 #define NUL '\0'
 #define isnull(X) (X == '\0' ? TRUE : FALSE)
 #define notnull(X) (X == '\0' ? FALSE : TRUE)
-#define isspace(X) ((X == ' ') || (X == '\011'))
 
 /*
 flags for expand. Report and ignore errors, and no_target means error if
@@ -1182,10 +1182,11 @@ readmakefile(s) char *s;
             my_strcpy(tempdep, fword);
 
             /* be sure object extension has no spaces */
-            for (k = i + 1; notnull(fword[k]) && !isspace(fword[k]); k++)
+            for (k = i + 1;
+                 notnull(fword[k]) && !std::isspace(static_cast<unsigned char>(fword[k])); k++)
                 ;
 
-            if (isspace(fword[k]))
+            if (std::isspace(static_cast<unsigned char>(fword[k])))
                 fword[k] = NUL;
             my_strcpy(temp, ".");
             strcat(temp, fword + i + 1); /* targ */
@@ -1334,7 +1335,7 @@ getnxt() {
                 /* found DIRECTIVE -- .XXXXX: */
                 line[mark] = NUL;
                 fword = line + 1;
-                for (x++; isspace(line[x]); x++)
+                for (x++; std::isspace(static_cast<unsigned char>(line[x])); x++)
                     ;
                 restline = line + x;
                 return (DIRECTIVE);
@@ -1360,7 +1361,7 @@ getnxt() {
                       is a '#', in which case we ignore the comment
                     */
                     for (pos++; line[pos] != ';' && notnull(line[pos]); pos++)
-                        if (!isspace(line[pos]))
+                        if (!std::isspace(static_cast<unsigned char>(line[pos])))
                             break;
                     if (notnull(line[pos])) {
                         if (line[pos] == '#')
@@ -1382,14 +1383,15 @@ getnxt() {
         /* check for macro, and return it if there */
         if (!parsed) {
             pos = 0;
-            while (line[pos] != '=' && line[pos] != ':' && !isspace(line[pos]) &&
-                   notnull(line[pos]))
+            while (line[pos] != '=' && line[pos] != ':' &&
+                   !std::isspace(static_cast<unsigned char>(line[pos])) && notnull(line[pos]))
                 pos++;
             mark = pos;
             if (notnull(line[pos]) && line[pos] != ':') {
                 /* found a macro */
-                if (isspace(line[pos]))
-                    while (isspace(line[pos]) && notnull(line[pos]))
+                if (std::isspace(static_cast<unsigned char>(line[pos])))
+                    while (std::isspace(static_cast<unsigned char>(line[pos])) &&
+                           notnull(line[pos]))
                         pos++;
                 if (isnull(line[pos]))
                     panic2("bad macro or definition '%s'", line);
@@ -1398,7 +1400,7 @@ getnxt() {
                     line[mark] = NUL;
                     fword = line;
                     mark = pos + 1;
-                    while (isspace(line[mark]))
+                    while (std::isspace(static_cast<unsigned char>(line[mark])))
                         mark++; /* skip spaces before macro starts */
                     restline = line + mark;
                     return (AMACRO);
@@ -1407,7 +1409,7 @@ getnxt() {
         }
 
         /* check for and add howto line */
-        if (isspace(line[0])) {
+        if (std::isspace(static_cast<unsigned char>(line[0]))) {
             if (!def_ready && !rule_ready)
                 error2("how-to line without preceeding definition or rule\n%s", line);
             q_how2 = MkListMem();
@@ -1506,7 +1508,7 @@ FILE *stream;
             return (FALSE);
 
         /* if the line is only <ws> or <ws>#, skip it */
-        for (x = 0; isspace(where[x]) && (where[x] != '\n'); x++)
+        for (x = 0; std::isspace(static_cast<unsigned char>(where[x])) && (where[x] != '\n'); x++)
             ;
         if ((where[x] == '\n') || (where[x] == '#'))
             continue;
@@ -1553,7 +1555,7 @@ int p;
 
     i = 0;
     dest[0] = NUL;
-    while (notnull(src[p]) && isspace(src[p]))
+    while (notnull(src[p]) && std::isspace(static_cast<unsigned char>(src[p])))
         p++;
     if (isnull(src[p]))
         return (p);
@@ -1571,7 +1573,7 @@ int p;
             if (src[p + 1] == '"')
                 p++;
             dest[i++] = src[p++];
-        } else if (!quotestop && isspace(src[p]))
+        } else if (!quotestop && std::isspace(static_cast<unsigned char>(src[p])))
             break;
         else if (quotestop && (src[p] == '"'))
             break;
@@ -1604,7 +1606,7 @@ int eflag;
             my_strcpy(temp, head->name);
         p = MkListMem();
         for (x = 0; notnull(temp[x]); x++)
-            if (!isspace(temp[x]))
+            if (!std::isspace(static_cast<unsigned char>(temp[x])))
                 break;
         p->name = mov_in(temp + x);
         p->next = NULL;
@@ -1798,7 +1800,7 @@ exec_how(cmd) char *cmd;
     this_ign = FALSE;
     no_more_flags = FALSE;
     while (TRUE) {
-        while (isspace(cmd[pos]))
+        while (std::isspace(static_cast<unsigned char>(cmd[pos])))
             pos++;
         switch (cmd[pos]) {
         case '@':
@@ -1820,7 +1822,7 @@ exec_how(cmd) char *cmd;
     }
 
     /* get the name of the command */
-    for (x = pos; !isspace(cmd[x]) && notnull(cmd[x]); x++)
+    for (x = pos; !std::isspace(static_cast<unsigned char>(cmd[x])) && notnull(cmd[x]); x++)
         cmdname[i++] = cmd[x];
     cmdname[i] = NUL;
 
@@ -2045,7 +2047,7 @@ static void squeezesp(char *to, char *from) {
     if (from == NULL)
         return;
     while (*from) {
-        if (isspace(*from))
+        if (std::isspace(static_cast<unsigned char>(*from)))
             from++;
         else
             *to++ = *from++;

--- a/commands/uniq.cpp
+++ b/commands/uniq.cpp
@@ -18,8 +18,8 @@
  */
 
 #define WRITE_ERROR 1
-#define isdigit(c) (c >= '0' && c <= '9')
 #include "stdio.hpp"
+#include <cctype>
 
 FILE *fopen();
 char buffer[BUFSIZ];
@@ -53,7 +53,7 @@ main(argc, argv) char *argv[];
     for (--argc, ++argv; argc > 0 && (**argv == '-' || **argv == '+'); --argc, ++argv) {
         if (**argv == '+')
             chars = atoi(*argv + 1);
-        else if (isdigit(argv[0][1]))
+        else if (std::isdigit(static_cast<unsigned char>(argv[0][1])))
             fields = atoi(*argv + 1);
         else if (argv[0][1] == '\0')
             inf = 0; /* - is stdin */

--- a/commands/wc.cpp
+++ b/commands/wc.cpp
@@ -7,8 +7,7 @@
 /* wc - count lines, words and characters	Author: David Messer */
 
 #include "stdio.hpp"
-#define isdigit(c) (c >= '0' && c <= '9)
-#define isspace(c) (c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r')
+#include <cctype>
 
 /*
  *
@@ -149,7 +148,7 @@ count() {
     while ((c = getc(stdin)) > 0) {
         ccount++;
 
-        if (isspace(c)) {
+        if (std::isspace(static_cast<unsigned char>(c))) {
             if (word)
                 wcount++;
             word = 0;

--- a/tools/fsck.cpp
+++ b/tools/fsck.cpp
@@ -5,6 +5,7 @@
 #include "../h/const.hpp"
 #include "../h/type.hpp"
 #include "../include/lib.hpp" // C++17 header
+#include <cctype>
 
 /* #define DOS			/* compile to run under MS-DOS */
 #define STANDALONE /* compile for the boot-diskette */
@@ -79,11 +80,6 @@
 #define PARB 6
 
 #define between(c, l, u) ((unsigned short)((c) - (l)) <= ((u) - (l)))
-#define isprint(c) between(c, ' ', '~')
-#define isdigit(c) between(c, '0', '9')
-#define islower(c) between(c, 'a', 'z')
-#define isupper(c) between(c, 'A', 'Z')
-#define toupper(c) ((c) + 'A' - 'a')
 
 #define quote(x) x
 #define nextarg(t) (*argp.quote(u_) t++)
@@ -277,7 +273,7 @@ int width, pad;
 /* Print the character c.
  */
 printchar(c, mode) {
-    if (mode == 0 || (isprint(c) && c != '\\')) {
+    if (mode == 0 || (std::isprint(static_cast<unsigned char>(c)) && c != '\\')) {
         putchar(c);
         return (1);
     } else {
@@ -332,13 +328,13 @@ union types argp;
                 fmt++;
             pad = *fmt == '0' ? '0' : ' ';
             width = 0;
-            while (isdigit(*fmt)) {
+            while (std::isdigit(static_cast<unsigned char>(*fmt))) {
                 width *= 10;
                 width += *fmt++ - '0';
             }
-            if (*fmt == 'l' && islower(*++fmt))
-                *fmt = toupper(*fmt);
-            mode = isupper(*fmt);
+            if (*fmt == 'l' && std::islower(static_cast<unsigned char>(*++fmt)))
+                *fmt = std::toupper(static_cast<unsigned char>(*fmt));
+            mode = std::isupper(static_cast<unsigned char>(*fmt));
             switch (*fmt) {
             case 'c':
             case 'C':
@@ -538,7 +534,7 @@ printname(s) char *s;
     do {
         if (*s == 0)
             break;
-        printf("%c", isprint(*s) ? *s : '?');
+        printf("%c", std::isprint(static_cast<unsigned char>(*s)) ? *s : '?');
         s++;
     } while (--n);
 }
@@ -748,7 +744,7 @@ char *s;
     if (s == 0)
         return (NO_BIT);
     while (*s != 0) {
-        if (!isdigit(*s))
+        if (!std::isdigit(static_cast<unsigned char>(*s)))
             return (NO_BIT);
         n *= 10;
         n += *s++ - '0';


### PR DESCRIPTION
## Summary
- replace custom classification macros in utilities with `<cctype>`
- use `std::isprint`, `std::isdigit`, `std::islower`, `std::isupper`, `std::toupper`, and `std::isspace`
- format updated files

## Testing
- `make -k` *(fails: missing build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683a1c181b3883319a81c5a3bf9e76ae