### PR TITLE
Deduplicate atoi/atol parsing

### DIFF
--- a/include/number_parse.hpp
+++ b/include/number_parse.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cctype> // for std::isspace
+
+// Parse a signed decimal string and return the resulting value as a long.
+// Leading whitespace is skipped and an optional leading '-' is honored.
+// Parsing stops at the first non-digit character.
+static inline long parse_signed_decimal(const char *str) {
+    // Convert to unsigned char pointer for safe character math.
+    const unsigned char *s = reinterpret_cast<const unsigned char *>(str);
+
+    long total = 0; // running value computed from the digits
+    int minus = 0;  // track whether a leading minus was present
+
+    // Skip over any leading whitespace characters.
+    while (std::isspace(*s)) {
+        ++s;
+    }
+
+    // Check for an optional '-' sign to mark a negative value.
+    if (*s == '-') {
+        minus = 1;
+        ++s;
+    }
+
+    // Accumulate digit values until a non-digit character is seen.
+    unsigned digit;
+    while ((digit = *s - '0') < 10) {
+        total = total * 10 + digit;
+        ++s;
+    }
+
+    return minus ? -total : total;
+}

--- a/lib/atoi.cpp
+++ b/lib/atoi.cpp
@@ -1,30 +1,10 @@
 /* Implementation of the standard atoi() function. */
 
-#include <cctype> // for std::isspace and friends
-#include <cstdlib>
+#include "../include/number_parse.hpp" // shared decimal parser
 
-/* Convert a numeric string to an integer. */
+/* Convert a numeric string to an int using the shared parser. */
 int atoi(const char *s) {
-    int total = 0;  /* running total */
-    unsigned digit; /* current digit */
-    int minus = 0;  /* track a leading '-' */
-
-    /* Skip leading whitespace characters. */
-    while (std::isspace(static_cast<unsigned char>(*s))) {
-        s++;
-    }
-
-    /* Handle optional leading minus sign. */
-    if (*s == '-') {
-        s++;
-        minus = 1;
-    }
-
-    /* Process digits until a non-digit is encountered. */
-    while ((digit = *s++ - '0') < 10) {
-        total *= 10;
-        total += digit;
-    }
-
-    return minus ? -total : total;
+    // Use the common helper to parse a signed decimal value and
+    // narrow the result to an int for backwards compatibility.
+    return static_cast<int>(parse_signed_decimal(s));
 }

--- a/lib/atol.cpp
+++ b/lib/atol.cpp
@@ -1,27 +1,8 @@
-#include <cctype> // for std::isspace
-#include <cstdlib>
+#include "../include/number_parse.hpp" // shared decimal parser
 
-/* Convert a string to a long integer. */
+/* Convert a string to a long integer using the common parser. */
 long atol(char *s) {
-    long total = 0; /* running total */
-    unsigned digit; /* current digit */
-    int minus = 0;  /* leading '-' seen */
-
-    /* Skip whitespace characters. */
-    while (std::isspace(static_cast<unsigned char>(*s)))
-        s++;
-
-    /* Check for a sign prefix. */
-    if (*s == '-') {
-        s++;
-        minus = 1;
-    }
-
-    /* Accumulate decimal digits. */
-    while ((digit = *s++ - '0') < 10) {
-        total *= 10;
-        total += digit;
-    }
-
-    return minus ? -total : total;
+    // The historical prototype expects a mutable char pointer, so
+    // simply pass it to the helper which takes a const pointer.
+    return parse_signed_decimal(s);
 }


### PR DESCRIPTION
## Summary
- centralize decimal number parsing in a new header
- simplify `atoi` and `atol` using the shared helper

## Testing
- `cmake ..`
- `make lib_test`
- `make syscall_test`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683b34d952a883319b0f2dbb6fdecbc7